### PR TITLE
refactor/cleanup nodesByLabel lookup

### DIFF
--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
@@ -157,7 +157,7 @@ public abstract class OdbNode implements Vertex {
     }
     OdbIndex.removeElementIndex(this);
     graph.nodes.remove(ref.id);
-    graph.getElementsByLabel(graph.nodesByLabel, label()).remove(this);
+    graph.nodesByLabel.get(label()).remove(this);
 
     graph.storage.removeNode(ref.id);
 //        this.modifiedSinceLastSerialization = true;

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/tp3/optimizations/OdbGraphStep.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/tp3/optimizations/OdbGraphStep.java
@@ -59,9 +59,11 @@ public final class OdbGraphStep<S, E extends Element> extends GraphStep<S, E> im
       return Collections.emptyIterator();
     else if (this.ids.length > 0)
       return this.iteratorList(graph.vertices(this.ids));
-    else if (hasLabelContainer.isPresent())
-      return graph.nodesByLabel((P<String>) hasLabelContainer.get().getPredicate());
-    else {
+    else if (hasLabelContainer.isPresent()) {
+      P<String> hasLabelPredicate = (P<String>) hasLabelContainer.get().getPredicate();
+      // unfortunately TP3 api doesn't seem to find out if it's the `Compare.eq` bipredicate, so we can optimise single-label lookups
+      return graph.nodesByLabel(hasLabelPredicate);
+    } else {
       if (indexedContainer == null) return this.iteratorList(graph.vertices());
       else {
         return IteratorUtils.filter(


### PR DESCRIPTION
Add optimization for single-label lookup (the most common case), which
we will use in the upcoming non-tinkerpop traversals.
I tried to use it for the tinkerpop traversal as well, but can't find
a way (outside the debugger) to tell if it's a `Compare.eq`
BiPredicate.