### PR TITLE
fix java 1.8 compat

### DIFF
--- a/tinkerpop3/build.sbt
+++ b/tinkerpop3/build.sbt
@@ -17,3 +17,4 @@ Test/testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v")
 Test/compile/javacOptions ++= Seq("-g")
 Test/fork := true
 scalacOptions ++= Seq("-deprecation", "-feature")
+javacOptions ++= Seq("-target", "1.8")

--- a/tinkerpop3/build.sbt
+++ b/tinkerpop3/build.sbt
@@ -18,3 +18,4 @@ Test/compile/javacOptions ++= Seq("-g")
 Test/fork := true
 scalacOptions ++= Seq("-deprecation", "-feature")
 javacOptions ++= Seq("-target", "1.8")
+javacOptions ++= Seq("-source", "1.8")


### PR DESCRIPTION
Interop with codepropertygraphs broke after v.20. Tests work locally with this.