### PR TITLE
optimization for serialization: unique ids for node labels

### DIFF
--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/NodeFactory.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/NodeFactory.java
@@ -2,7 +2,15 @@ package io.shiftleft.overflowdb;
 
 public abstract class NodeFactory<V extends OdbNode> {
   public abstract String forLabel();
+
+  /** unique id for this node's label
+   *  This is mostly an optimization for storage - we could as well serialize labels as string, but numbers are more efficient.
+   *  Since we know our schema at compile time, we can assign unique ids for each label.
+   *  */
+  public abstract int forLabelId();
+
   public abstract V createNode(NodeRef<V> ref);
+
   public abstract NodeRef<V> createNodeRef(OdbGraph graph, long id);
 
   public V createNode(OdbGraph graph, long id) {
@@ -11,5 +19,6 @@ public abstract class NodeFactory<V extends OdbNode> {
     ref.setNode(node);
     return node;
   }
+
 }
 

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/NodeLayoutInformation.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/NodeLayoutInformation.java
@@ -11,13 +11,17 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 /**
- * Contains all static node-specific information. This could in theory be part of OverflowDbNode, but to save memory
- * we need to minimize the amount of fields per node instance. While there may be millions of node instances, there's
- * only one NodeLayoutInformation instance per node type, which holds this static information.
+ * Contains all static node-specific information for serialization / deserialization.
  * <p>
  * Please make sure to instantiate only one instance per node type to not waste memory.
  */
 public class NodeLayoutInformation {
+  /** unique id for this node's label
+   *  This is mostly an optimization for storage - we could as well serialize labels as string, but numbers are more efficient.
+   *  Since we know our schema at compile time, we can assign unique ids for each label.
+   *  */
+  public final int labelId;
+
   private final Set<String> propertyKeys;
   private final String[] allowedOutEdgeLabels;
   private final String[] allowedInEdgeLabels;
@@ -39,9 +43,11 @@ public class NodeLayoutInformation {
    * 1-based, because index `0` is the adjacent node ref */
   private final Map<LabelAndKey, Integer> edgeLabelAndKeyToStrideIndex;
 
-  public NodeLayoutInformation(Set<String> propertyKeys,
+  public NodeLayoutInformation(int labelId,
+                               Set<String> propertyKeys,
                                List<EdgeLayoutInformation> outEdgeLayouts,
                                List<EdgeLayoutInformation> inEdgeLayouts) {
+    this.labelId = labelId;
     this.propertyKeys = propertyKeys;
 
     Set<EdgeLayoutInformation> allEdgeLayouts = new HashSet<>();

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
@@ -60,7 +60,7 @@ public abstract class OdbNode implements Vertex {
     edgeOffsets = PackedIntArray.create(layoutInformation().numberOfDifferentAdjacentTypes() * 2);
   }
 
-  protected abstract NodeLayoutInformation layoutInformation();
+  public abstract NodeLayoutInformation layoutInformation();
 
   protected abstract <V> Iterator<VertexProperty<V>> specificProperties(String key);
 

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeSerializer.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeSerializer.java
@@ -23,7 +23,7 @@ public class NodeSerializer {
     long start = System.currentTimeMillis();
     try (MessageBufferPacker packer = MessagePack.newDefaultBufferPacker()) {
       packer.packLong(node.ref.id);
-      packer.packString(node.label());
+      packer.packInt(node.layoutInformation().labelId);
 
       packProperties(packer, node.valueMap());
       packEdgeOffsets(packer, node.getEdgeOffsets());

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/storage/SerializerTest.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/storage/SerializerTest.java
@@ -82,8 +82,8 @@ public class SerializerTest {
   }
 
   private NodeDeserializer newDeserializer(OdbGraph graph) {
-    Map<String, NodeFactory> vertexFactories = new HashMap();
-    vertexFactories.put(TestNode.LABEL, TestNode.factory);
+    Map<Integer, NodeFactory> vertexFactories = new HashMap();
+    vertexFactories.put(TestNodeDb.layoutInformation.labelId, TestNode.factory);
     return new NodeDeserializer(graph, vertexFactories);
   }
 

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/Artist.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/Artist.java
@@ -28,6 +28,11 @@ public class Artist extends NodeRef<ArtistDb> {
     }
 
     @Override
+    public int forLabelId() {
+      return ArtistDb.layoutInformation.labelId;
+    }
+
+    @Override
     public ArtistDb createNode(NodeRef<ArtistDb> ref) {
       return new ArtistDb(ref);
     }

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/ArtistDb.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/ArtistDb.java
@@ -26,7 +26,7 @@ public class ArtistDb extends OdbNode {
   }
 
   @Override
-  protected NodeLayoutInformation layoutInformation() {
+  public NodeLayoutInformation layoutInformation() {
     return layoutInformation;
   }
 
@@ -67,7 +67,8 @@ public class ArtistDb extends OdbNode {
     }
   }
 
-  private static NodeLayoutInformation layoutInformation = new NodeLayoutInformation(
+  public static NodeLayoutInformation layoutInformation = new NodeLayoutInformation(
+      3,
       new HashSet<>(Arrays.asList(Artist.NAME)),
       Arrays.asList(),
       Arrays.asList(SungBy.layoutInformation, WrittenBy.layoutInformation));

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/Song.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/Song.java
@@ -38,6 +38,11 @@ public class Song extends NodeRef<SongDb> {
     }
 
     @Override
+    public int forLabelId() {
+      return SongDb.layoutInformation.labelId;
+    }
+
+    @Override
     public SongDb createNode(NodeRef<SongDb> ref) {
       return new SongDb(ref);
     }

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/SongDb.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/SongDb.java
@@ -36,7 +36,7 @@ public class SongDb extends OdbNode {
   }
 
   @Override
-  protected NodeLayoutInformation layoutInformation() {
+  public NodeLayoutInformation layoutInformation() {
     return layoutInformation;
   }
 
@@ -92,7 +92,8 @@ public class SongDb extends OdbNode {
     }
   }
 
-  private static NodeLayoutInformation layoutInformation = new NodeLayoutInformation(
+  public static NodeLayoutInformation layoutInformation = new NodeLayoutInformation(
+      1,
       new HashSet<>(Arrays.asList(Song.NAME, Song.SONG_TYPE, Song.PERFORMANCES)),
       Arrays.asList(SungBy.layoutInformation, WrittenBy.layoutInformation, FollowedBy.layoutInformation),
       Arrays.asList(FollowedBy.layoutInformation));

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/simple/TestNode.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/simple/TestNode.java
@@ -47,6 +47,11 @@ public class TestNode extends NodeRef<TestNodeDb> {
     }
 
     @Override
+    public int forLabelId() {
+      return TestNodeDb.layoutInformation.labelId;
+    }
+
+    @Override
     public TestNodeDb createNode(NodeRef<TestNodeDb> ref) {
       return new TestNodeDb(ref);
     }

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/simple/TestNodeDb.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/simple/TestNodeDb.java
@@ -43,7 +43,7 @@ public class TestNodeDb extends OdbNode {
   }
 
   @Override
-  protected NodeLayoutInformation layoutInformation() {
+  public NodeLayoutInformation layoutInformation() {
     return layoutInformation;
   }
 
@@ -115,7 +115,8 @@ public class TestNodeDb extends OdbNode {
     }
   }
 
-  private static NodeLayoutInformation layoutInformation = new NodeLayoutInformation(
+  public static NodeLayoutInformation layoutInformation = new NodeLayoutInformation(
+      2,
       new HashSet<>(Arrays.asList(TestNode.STRING_PROPERTY, TestNode.INT_PROPERTY, TestNode.STRING_LIST_PROPERTY, TestNode.INT_LIST_PROPERTY)),
       Arrays.asList(TestEdge.layoutInformation),
       Arrays.asList(TestEdge.layoutInformation));

--- a/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/gratefuldead/Artist.scala
+++ b/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/gratefuldead/Artist.scala
@@ -16,6 +16,7 @@ class Artist(graph: OdbGraph, id: Long) extends NodeRef[ArtistDb](graph, id) wit
 
 object Artist {
   val Label = "artist"
+  val LabelId = 4
 
   object Properties {
     val Name = PropertyKey[String](PropertyNames.Name)
@@ -27,13 +28,15 @@ object Artist {
   }
 
   val factory: NodeFactory[ArtistDb] = new NodeFactory[ArtistDb]() {
-    override def forLabel: String = Artist.Label
+    override def forLabel: String = Label
+    override def forLabelId() = LabelId
     override def createNode(ref: NodeRef[ArtistDb]) = new ArtistDb(ref)
     override def createNodeRef(graph: OdbGraph, id: Long) = new Artist(graph, id)
   }
 
   val layoutInformation: NodeLayoutInformation =
     new NodeLayoutInformation(
+      LabelId,
       PropertyNames.all.asJava,
       Nil.asJava,
       List(SungBy.layoutInformation, WrittenBy.layoutInformation).asJava

--- a/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/gratefuldead/Song.scala
+++ b/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/gratefuldead/Song.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.overflowdb.traversal.testdomains.gratefuldead
 
+import io.shiftleft.overflowdb.traversal.testdomains.gratefuldead.Artist.LabelId
 import io.shiftleft.overflowdb.traversal.{NodeRefOps, PropertyKey, Traversal}
 import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph}
 
@@ -18,6 +19,7 @@ class Song(graph: OdbGraph, id: Long) extends NodeRef[SongDb](graph, id) with No
 
 object Song {
   val Label = "song"
+  val LabelId = 5
 
   object Properties {
     val Name = PropertyKey[String](PropertyNames.Name)
@@ -33,13 +35,15 @@ object Song {
   }
 
   val factory: NodeFactory[SongDb] = new NodeFactory[SongDb]() {
-    override def forLabel: String = Song.Label
+    override def forLabel: String = Label
+    override def forLabelId() = LabelId
     override def createNode(ref: NodeRef[SongDb]) = new SongDb(ref)
     override def createNodeRef(graph: OdbGraph, id: Long) = new Song(graph, id)
   }
 
   val layoutInformation: NodeLayoutInformation =
     new NodeLayoutInformation(
+      LabelId,
       PropertyNames.all.asJava,
       List(SungBy.layoutInformation, WrittenBy.layoutInformation, FollowedBy.layoutInformation).asJava,
       List(FollowedBy.layoutInformation).asJava

--- a/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/simple/Thing.scala
+++ b/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/simple/Thing.scala
@@ -18,6 +18,7 @@ class Thing(graph: OdbGraph, id: Long) extends NodeRef[ThingDb](graph, id) with 
 
 object Thing {
   val Label = "thing"
+  val LabelId = 6
 
   object Properties {
     val Name = PropertyKey[String](PropertyNames.Name)
@@ -29,13 +30,15 @@ object Thing {
   }
 
   val factory: NodeFactory[ThingDb] = new NodeFactory[ThingDb]() {
-    override def forLabel: String = Thing.Label
+    override def forLabel: String = Label
+    override def forLabelId() = LabelId
     override def createNode(ref: NodeRef[ThingDb]) = new ThingDb(ref)
     override def createNodeRef(graph: OdbGraph, id: Long) = new Thing(graph, id)
   }
 
   val layoutInformation: NodeLayoutInformation =
     new NodeLayoutInformation(
+      LabelId,
       PropertyNames.all.asJava,
       List(Connection.layoutInformation).asJava,
       List(Connection.layoutInformation).asJava


### PR DESCRIPTION
This is mostly an optimization for storage - we could as well serialize labels as string, but numbers are more efficient.
Since we know our schema at compile time, we can assign unique ids for each label.