### PR TITLE
remove intellij-sbt compat pathconfigs

### DIFF
--- a/tinkerpop3/build.sbt
+++ b/tinkerpop3/build.sbt
@@ -17,8 +17,6 @@ libraryDependencies ++= Seq(
 autoScalaLibrary := false
 crossPaths := false
 
-// execute tests in root project so that they work in sbt *and* intellij
-Test/baseDirectory := (ThisBuild / Test / run / baseDirectory).value
 Test/testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v")
 Test/compile/javacOptions ++= Seq("-g", "-target", "1.8")
 Test/fork := true

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/storage/GraphSaveRestoreTest.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/storage/GraphSaveRestoreTest.java
@@ -92,7 +92,7 @@ public class GraphSaveRestoreTest {
   }
 
   private void loadGraphMl(OdbGraph graph) throws IOException {
-    graph.io(IoCore.graphml()).readGraph("src/test/resources/grateful-dead.xml");
+    graph.io(IoCore.graphml()).readGraph("../src/test/resources/grateful-dead.xml");
   }
 
 }

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/GratefulDead.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/testdomains/gratefuldead/GratefulDead.java
@@ -27,7 +27,7 @@ public class GratefulDead {
   }
 
   public static void loadData(OdbGraph graph) throws IOException {
-    graph.io(IoCore.graphml()).readGraph("src/test/resources/grateful-dead.xml");
+    graph.io(IoCore.graphml()).readGraph("../src/test/resources/grateful-dead.xml");
   }
 
 

--- a/traversal/build.sbt
+++ b/traversal/build.sbt
@@ -5,9 +5,6 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-simple" % "1.7.28" % Test,
 )
 
-// execute tests in root project so that they work in sbt *and* intellij
-Test/baseDirectory := (ThisBuild/Test/run/baseDirectory).value
-
 Test/console/scalacOptions -= "-Xlint"
 Test/console/initialCommands :=
   """|import io.shiftleft.overflowdb.traversal._


### PR DESCRIPTION
These used to be required to ensure that tests could be run from both
sbt and intellij. But that's no longer the case, and in order to fix
intellij should be removed.