### PR TITLE
revive dirty flag to ensure we're only serializing when necessary

### DIFF
--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/NodeFactory.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/NodeFactory.java
@@ -16,6 +16,7 @@ public abstract class NodeFactory<V extends OdbNode> {
   public V createNode(OdbGraph graph, long id) {
     final NodeRef<V> ref = createNodeRef(graph, id);
     final V node = createNode(ref);
+    node.markAsDirty(); //freshly created, i.e. not yet serialized
     ref.setNode(node);
     return node;
   }

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbGraph.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbGraph.java
@@ -330,6 +330,10 @@ public final class OdbGraph implements Graph {
     return closed;
   }
 
+  public OdbStorage getStorage() {
+    return storage;
+  }
+
   public class GraphFeatures implements Features {
     private final OdbGraphFeatures graphFeatures = new OdbGraphFeatures();
     private final OdbEdgeFeatures edgeFeatures = new OdbEdgeFeatures();

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
@@ -28,17 +28,10 @@ import java.util.stream.StreamSupport;
  * Node that stores adjacent Nodes directly, rather than via edges.
  * Motivation: in many graph use cases, edges don't hold any properties and thus accounts for more memory and
  * traversal time than necessary
- *
- * TODO: remove tinkerpop dependency
  */
 public abstract class OdbNode implements Vertex {
 
   public final NodeRef ref;
-
-  @Override
-  public String label() {
-    return ref.label();
-  }
 
   /**
    * holds refs to all adjacent nodes (a.k.a. dummy edges) and the edge properties
@@ -48,6 +41,14 @@ public abstract class OdbNode implements Vertex {
   /* store the start offset and length into the above `adjacentNodesWithProperties` array in an interleaved manner,
    * i.e. each outgoing edge type has two entries in this array. */
   private PackedIntArray edgeOffsets;
+
+  /**
+   * Flag that helps us save time when serializing, both when overflowing to disk and when storing
+   * the graph on close.
+   * `true`  when node is first created, or is modified (property or edges)
+   * `false` when node is freshly serialized to disk or deserialized from disk
+   */
+  private boolean dirty;
 
   protected OdbNode(NodeRef ref) {
     this.ref = ref;
@@ -93,6 +94,11 @@ public abstract class OdbNode implements Vertex {
   }
 
   @Override
+  public String label() {
+    return ref.label();
+  }
+
+  @Override
   public Set<String> keys() {
     return layoutInformation().propertyKeys();
   }
@@ -135,12 +141,11 @@ public abstract class OdbNode implements Vertex {
   public <V> VertexProperty<V> property(VertexProperty.Cardinality cardinality, String key, V value, Object... keyValues) {
     ElementHelper.legalPropertyKeyValueArray(keyValues);
     ElementHelper.validateProperty(key, value);
-    synchronized (this) {
-//            this.modifiedSinceLastSerialization = true;
-      final VertexProperty<V> vp = updateSpecificProperty(cardinality, key, value);
-      ref.graph.indexManager.putIfIndexed(key, value, ref);
-      return vp;
-    }
+    final VertexProperty<V> vp = updateSpecificProperty(cardinality, key, value);
+    ref.graph.indexManager.putIfIndexed(key, value, ref);
+    /* marking as dirty *after* we updated - if node gets serialized before we finish, it'll be marked as dirty */
+    this.markAsDirty();
+    return vp;
   }
 
   protected abstract <V> VertexProperty<V> updateSpecificProperty(
@@ -163,12 +168,17 @@ public abstract class OdbNode implements Vertex {
     graph.nodesByLabel.get(label()).remove(this);
 
     graph.storage.removeNode(ref.id);
-//        this.modifiedSinceLastSerialization = true;
+    /* marking as dirty *after* we updated - if node gets serialized before we finish, it'll be marked as dirty */
+    this.markAsDirty();
   }
 
-//    public void setModifiedSinceLastSerialization(boolean modifiedSinceLastSerialization) {
-//        this.modifiedSinceLastSerialization = modifiedSinceLastSerialization;
-//    }
+  public void markAsDirty() {
+    this.dirty = true;
+  }
+
+  public void markAsClean() {
+    this.dirty = false;
+  }
 
   public <V> Iterator<Property<V>> getEdgeProperties(Direction direction,
                                                      OdbEdge edge,
@@ -214,6 +224,8 @@ public abstract class OdbNode implements Vertex {
       throw new RuntimeException("Edge " + edgeLabel + " does not support property " + key + ".");
     }
     adjacentNodesWithProperties[propertyPosition] = value;
+    /* marking as dirty *after* we updated - if node gets serialized before we finish, it'll be marked as dirty */
+    this.markAsDirty();
   }
 
   private int calcAdjacentNodeIndex(Direction direction,
@@ -334,7 +346,7 @@ public abstract class OdbNode implements Vertex {
    * @return the occurrence for a given edge, calculated by counting the number times the given
    * adjacent node occurred between the start of the edge-specific block and the blockOffset
    */
-  protected int blockOffsetToOccurrence(Direction direction,
+  protected final int blockOffsetToOccurrence(Direction direction,
                                      String label,
                                      NodeRef otherNode,
                                      int blockOffset) {
@@ -359,7 +371,7 @@ public abstract class OdbNode implements Vertex {
    *                   Both nodes use the same occurrence index for the same edge.
    * @return the index into `adjacentNodesWithProperties`
    */
-  protected int occurrenceToBlockOffset(Direction direction,
+  protected final int occurrenceToBlockOffset(Direction direction,
                                      String label,
                                      NodeRef adjacentNode,
                                      int occurrence) {
@@ -391,7 +403,7 @@ public abstract class OdbNode implements Vertex {
    *
    * @param blockOffset must have been initialized
    */
-  protected void removeEdge(Direction direction, String label, int blockOffset) {
+  protected final synchronized void removeEdge(Direction direction, String label, int blockOffset) {
     int offsetPos = getPositionInEdgeOffsets(direction, label);
     int start = startIndex(offsetPos) + blockOffset;
     int strideSize = getStrideSize(label);
@@ -399,6 +411,9 @@ public abstract class OdbNode implements Vertex {
     for (int i = start; i < start + strideSize; i++) {
       adjacentNodesWithProperties[i] = null;
     }
+
+    /* marking as dirty *after* we updated - if node gets serialized before we finish, it'll be marked as dirty */
+    this.markAsDirty();
   }
 
   private Iterator<Edge> createDummyEdgeIterator(Direction direction,
@@ -448,10 +463,13 @@ public abstract class OdbNode implements Vertex {
       }
     }
 
+    /* marking as dirty *after* we updated - if node gets serialized before we finish, it'll be marked as dirty */
+    this.markAsDirty();
+
     return blockOffset;
   }
 
-  private int storeAdjacentNode(Direction direction, String edgeLabel, NodeRef nodeRef) {
+  private final synchronized int storeAdjacentNode(Direction direction, String edgeLabel, NodeRef nodeRef) {
     int offsetPos = getPositionInEdgeOffsets(direction, edgeLabel);
     if (offsetPos == -1) {
       throw new RuntimeException("Edge of type " + edgeLabel + " with direction " + direction +
@@ -483,7 +501,7 @@ public abstract class OdbNode implements Vertex {
    * @return number of elements reserved in `adjacentNodesWithProperties` for a given edge label
    * includes space for the node ref and all properties
    */
-  private int getStrideSize(String edgeLabel) {
+  private final int getStrideSize(String edgeLabel) {
     int sizeForNodeRef = 1;
     Set<String> allowedPropertyKeys = layoutInformation().edgePropertyKeys(edgeLabel);
     return sizeForNodeRef + allowedPropertyKeys.size();
@@ -492,7 +510,7 @@ public abstract class OdbNode implements Vertex {
   /**
    * @return The position in edgeOffsets array. -1 if the edge label is not supported
    */
-  private int getPositionInEdgeOffsets(Direction direction, String label) {
+  private final int getPositionInEdgeOffsets(Direction direction, String label) {
     final Integer positionOrNull;
     if (direction == Direction.OUT) {
       positionOrNull = layoutInformation().outEdgeToOffsetPosition(label);
@@ -510,11 +528,11 @@ public abstract class OdbNode implements Vertex {
    * Returns the length of an edge type block in the adjacentNodesWithProperties array.
    * Length means number of index positions.
    */
-  private int blockLength(int offsetPosition) {
+  private final int blockLength(int offsetPosition) {
     return edgeOffsets.get(2 * offsetPosition + 1);
   }
 
-  private String[] calcInLabels(String... edgeLabels) {
+  private final String[] calcInLabels(String... edgeLabels) {
     if (edgeLabels.length != 0) {
       return edgeLabels;
     } else {
@@ -522,7 +540,7 @@ public abstract class OdbNode implements Vertex {
     }
   }
 
-  private String[] calcOutLabels(String... edgeLabels) {
+  private final String[] calcOutLabels(String... edgeLabels) {
     if (edgeLabels.length != 0) {
       return edgeLabels;
     } else {
@@ -537,7 +555,7 @@ public abstract class OdbNode implements Vertex {
    * (tradeoff between performance and memory).
    * grows with the square root of the double of the current capacity.
    */
-  private Object[] growAdjacentNodesWithProperties(int offsetPos,
+  private final synchronized Object[] growAdjacentNodesWithProperties(int offsetPos,
                                                    int strideSize,
                                                    int insertAt,
                                                    int currentLength) {
@@ -563,12 +581,14 @@ public abstract class OdbNode implements Vertex {
   /**
    * to follow the tinkerpop api, instantiate and return a dummy edge, which doesn't really exist in the graph
    */
-  protected OdbEdge instantiateDummyEdge(String label,
-                                         NodeRef outNode,
-                                         NodeRef inNode) {
+  protected final OdbEdge instantiateDummyEdge(String label, NodeRef outNode, NodeRef inNode) {
     final EdgeFactory edgeFactory = ref.graph.edgeFactoryByLabel.get(label);
     if (edgeFactory == null)
       throw new IllegalArgumentException("specializedEdgeFactory for label=" + label + " not found - please register on startup!");
     return edgeFactory.createEdge(ref.graph, outNode, inNode);
+  }
+
+  public final boolean isDirty() {
+    return dirty;
   }
 }

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNodeProperty.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNodeProperty.java
@@ -63,6 +63,7 @@ public class OdbNodeProperty<V> implements Element, VertexProperty<V> {
 
   @Override
   public void remove() {
+    throw new RuntimeException("Not supported.");
   }
 
   @Override

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeDeserializer.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeDeserializer.java
@@ -168,6 +168,7 @@ public class NodeDeserializer {
     ElementHelper.attachProperties(node, VertexProperty.Cardinality.list, toTinkerpopKeyValues(properties));
     node.setEdgeOffsets(edgeOffsets);
     node.setAdjacentNodesWithProperties(adjacentNodesWithProperties);
+    node.markAsClean();
 
     return node;
   }

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeSerializer.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeSerializer.java
@@ -22,6 +22,9 @@ public class NodeSerializer {
   public byte[] serialize(OdbNode node) throws IOException {
     long start = System.currentTimeMillis();
     try (MessageBufferPacker packer = MessagePack.newDefaultBufferPacker()) {
+      /* marking as clean *before* we start serializing - if node is modified any time afterwards it'll be marked as dirty */
+      node.markAsClean();
+
       packer.packLong(node.ref.id);
       packer.packInt(node.layoutInformation().labelId);
 
@@ -116,4 +119,7 @@ public class NodeSerializer {
     }
   }
 
+  public final int getSerializedCount() {
+    return serializedCount;
+  }
 }

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/OdbStorage.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/OdbStorage.java
@@ -1,6 +1,5 @@
 package io.shiftleft.overflowdb.storage;
 
-import io.shiftleft.overflowdb.NodeRef;
 import io.shiftleft.overflowdb.OdbNode;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.h2.mvstore.MVMap;

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/storage/GraphSaveRestoreTest.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/storage/GraphSaveRestoreTest.java
@@ -2,9 +2,12 @@ package io.shiftleft.overflowdb.storage;
 
 import io.shiftleft.overflowdb.OdbConfig;
 import io.shiftleft.overflowdb.OdbGraph;
+import io.shiftleft.overflowdb.testdomains.gratefuldead.Artist;
 import io.shiftleft.overflowdb.testdomains.gratefuldead.FollowedBy;
 import io.shiftleft.overflowdb.testdomains.gratefuldead.GratefulDead;
 import io.shiftleft.overflowdb.testdomains.gratefuldead.Song;
+import io.shiftleft.overflowdb.testdomains.gratefuldead.SungBy;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -14,6 +17,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 
@@ -24,13 +28,13 @@ public class GraphSaveRestoreTest {
 
   @Test
   public void greenField() throws IOException {
-    final File overflowDb = Files.createTempFile("overflowdb", "bin").toFile();
-    overflowDb.deleteOnExit();
+    final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
+    storageFile.deleteOnExit();
 
     final Long vertex0Id;
     final Long vertex1Id;
     // create graph and store in specified location
-    try (OdbGraph graph = newGratefulDeadGraph(overflowDb, false)) {
+    try (OdbGraph graph = newGratefulDeadGraph(storageFile, false)) {
       Vertex v0 = graph.addVertex(T.label, Song.label, Song.NAME, "Song 1");
       Vertex v1 = graph.addVertex(T.label, Song.label, Song.NAME, "Song 2");
       Edge edge = v0.addEdge(FollowedBy.LABEL, v1, FollowedBy.WEIGHT, 42);
@@ -39,7 +43,7 @@ public class GraphSaveRestoreTest {
     } // ARM auto-close will trigger saving to disk because we specified a location
 
     // reload from disk
-    try (OdbGraph graph = newGratefulDeadGraph(overflowDb, false)) {
+    try (OdbGraph graph = newGratefulDeadGraph(storageFile, false)) {
       assertEquals(Long.valueOf(2), graph.traversal().V().count().next());
       assertEquals(Long.valueOf(1), graph.traversal().V().outE().count().next());
       assertEquals("Song 1", graph.vertex(vertex0Id).value(Song.NAME));
@@ -56,15 +60,15 @@ public class GraphSaveRestoreTest {
 
   @Test
   public void completeGratefulDeadGraph() throws IOException {
-    final File overflowDb = Files.createTempFile("overflowdb", "bin").toFile();
-    overflowDb.deleteOnExit();
+    final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
+    storageFile.deleteOnExit();
 
-    try (OdbGraph graph = newGratefulDeadGraph(overflowDb, false)) {
+    try (OdbGraph graph = newGratefulDeadGraph(storageFile, false)) {
       loadGraphMl(graph);
     } // ARM auto-close will trigger saving to disk because we specified a location
 
     // reload from disk
-    try (OdbGraph graph = newGratefulDeadGraph(overflowDb, false)) {
+    try (OdbGraph graph = newGratefulDeadGraph(storageFile, false)) {
       assertEquals(Long.valueOf(808), graph.traversal().V().count().next());
       assertEquals(Long.valueOf(8049), graph.traversal().V().outE().count().next());
     }
@@ -72,18 +76,95 @@ public class GraphSaveRestoreTest {
 
   @Test
   public void completeGratefulDeadGraphWithOverflowEnabled() throws IOException {
-    final File overflowDb = Files.createTempFile("overflowdb", "bin").toFile();
-    overflowDb.deleteOnExit();
+    final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
+    storageFile.deleteOnExit();
 
-    try (OdbGraph graph = newGratefulDeadGraph(overflowDb, true)) {
+    try (OdbGraph graph = newGratefulDeadGraph(storageFile, true)) {
       loadGraphMl(graph);
     } // ARM auto-close will trigger saving to disk because we specified a location
 
     // reload from disk
-    try (OdbGraph graph = newGratefulDeadGraph(overflowDb, true)) {
+    try (OdbGraph graph = newGratefulDeadGraph(storageFile, true)) {
       assertEquals(Long.valueOf(808), graph.traversal().V().count().next());
       assertEquals(Long.valueOf(8049), graph.traversal().V().outE().count().next());
     }
+  }
+
+  @Test
+  public void shouldOnlySerializeChangedNodes() throws IOException {
+    final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
+    storageFile.deleteOnExit();
+
+    modifyAndCloseGraph(storageFile, graph -> {
+      // initial import from graphml - should serialize all nodes
+      loadGraphMl(graph);
+      return 808;
+    });
+
+    modifyAndCloseGraph(storageFile, graph -> {
+      // no changes, not even traversing (and thus not deserializing nodes)
+      return 0;
+    });
+
+    modifyAndCloseGraph(storageFile, graph -> {
+      // traversing (and thus deserializing nodes), but making no changes
+      graph.traversal().V().has(Artist.NAME, "Garcia").next();
+      return 0;
+    });
+
+    modifyAndCloseGraph(storageFile, graph -> {
+      // new node, connected with existing node 'garcia'
+      Vertex newSong = graph.addVertex(Song.label);
+      newSong.property(Song.NAME, "new song");
+      Vertex youngBlood = graph.traversal().V().has(Song.NAME, "YOUNG BLOOD").next();
+      youngBlood.addEdge(FollowedBy.LABEL, newSong);
+      return 2; // both youngBlood and newSong should be serialized
+    });
+
+    modifyAndCloseGraph(storageFile, graph -> {
+      // update node property
+      Vertex newSong = graph.traversal().V().has(Song.NAME, "new song").next();
+      newSong.property(Song.PERFORMANCES, 5);
+      return 1;
+    });
+
+    // TODO implement property removal (both node and edge)
+//    modifyAndCloseGraph(storageFile, graph -> {
+//      // remove node property
+//      Vertex newSong = graph.traversal().V().has(Song.NAME, "new song").next();
+//      newSong.property(Song.PERFORMANCES).remove();
+//      return 1;
+//    });
+
+    modifyAndCloseGraph(storageFile, graph -> {
+      // update edge property
+      Vertex newSong = graph.traversal().V().has(Song.NAME, "new song").next();
+      Edge followedBy = newSong.edges(Direction.IN).next();
+      followedBy.property(FollowedBy.WEIGHT, 10);
+      return 2;  // both youngBlood and newSong should be serialized
+    });
+
+    modifyAndCloseGraph(storageFile, graph -> {
+      // remove edge
+      Vertex newSong = graph.traversal().V().has(Song.NAME, "new song").next();
+      Edge followedBy = newSong.edges(Direction.IN).next();
+      followedBy.remove();
+      return 2;  // both youngBlood and newSong should be serialized
+    });
+
+    modifyAndCloseGraph(storageFile, graph -> {
+      // remove node
+      Vertex newSong = graph.traversal().V().has(Song.NAME, "new song").next();
+      newSong.remove();
+      return 1;
+    });
+  }
+
+  private void modifyAndCloseGraph(File storageFile, Function<OdbGraph, Integer> graphModifications) {
+    OdbGraph graph = newGratefulDeadGraph(storageFile, false);
+    int expectedSerializationCount = graphModifications.apply(graph);
+    graph.close();
+    assertEquals(expectedSerializationCount, graph.getStorage().nodeSerializer.getSerializedCount());
   }
 
   private OdbGraph newGratefulDeadGraph(File overflowDb, boolean enableOverflow) {
@@ -91,8 +172,12 @@ public class GraphSaveRestoreTest {
     return GratefulDead.newGraph(config.withStorageLocation(overflowDb.getAbsolutePath()));
   }
 
-  private void loadGraphMl(OdbGraph graph) throws IOException {
-    graph.io(IoCore.graphml()).readGraph("../src/test/resources/grateful-dead.xml");
+  private void loadGraphMl(OdbGraph graph) throws RuntimeException {
+    try {
+      graph.io(IoCore.graphml()).readGraph("../src/test/resources/grateful-dead.xml");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
 }

--- a/traversal/src/main/scala/io/shiftleft/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/io/shiftleft/overflowdb/traversal/Traversal.scala
@@ -106,17 +106,17 @@ class Traversal[A](elements: IterableOnce[A])
 object Traversal extends IterableFactory[Traversal] {
   protected val logger = LoggerFactory.getLogger("Traversal")
 
-  def empty[A]: Traversal[A] = new Traversal(Iterator.empty)
+  override def empty[A]: Traversal[A] = new Traversal(Iterator.empty)
 
   def apply[A](elements: IterableOnce[A]) = new Traversal[A](elements.iterator)
 
   def apply[A](elements: java.util.Iterator[A]) =
     new Traversal[A](elements.asScala)
 
-  def newBuilder[A]: mutable.Builder[A, Traversal[A]] =
+  override def newBuilder[A]: mutable.Builder[A, Traversal[A]] =
     Iterator.newBuilder[A].mapResult(new Traversal(_))
 
-  def from[A](iter: IterableOnce[A]): Traversal[A] =
+  override def from[A](iter: IterableOnce[A]): Traversal[A] =
     new Traversal(Iterator.from(iter))
 
   def from[A](iter: IterableOnce[A], a: A): Traversal[A] = {


### PR DESCRIPTION
* also handle for multiple threads
* added synchronization to a bunch of other locations
* added `final` to a bunch of methods to help JITc
* multi threading scenario1: node is updated while it's read from storage in another thread: handled by synchronization in NodeRef.get
* multi threading scenario2: node or edge is updated while it's serialized
  * on close: not a problem because graph is immutable
  * on overflow: ok because serializer marks it as clean *before* it starts and updating the node marks it as dirty *after* it starts