### PR TITLE
trim overallocations, intern strings in deserialization, improve timings

### DIFF
--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
@@ -571,4 +571,28 @@ public abstract class OdbNode implements Vertex {
       throw new IllegalArgumentException("specializedEdgeFactory for label=" + label + " not found - please register on startup!");
     return edgeFactory.createEdge(ref.graph, outNode, inNode);
   }
+  /**
+   * Trims the node to save storage: shrinks overallocations
+   * */
+  public int trim(){
+    int newSize = 0;
+    for(int offsetPos = 0; 2*offsetPos < edgeOffsets.length(); offsetPos++){
+      int length = blockLength(offsetPos);
+      newSize += length;
+    }
+    Object[] newArray = new Object[newSize];
+
+    int off = 0;
+    for(int offsetPos = 0; 2*offsetPos < edgeOffsets.length(); offsetPos++){
+      int start = startIndex(offsetPos);
+      int length = blockLength(offsetPos);
+      System.arraycopy(adjacentNodesWithProperties, start, newArray, off, length);
+      edgeOffsets.set(2 * offsetPos, off);
+      off += length;
+    }
+    int oldsize = adjacentNodesWithProperties.length;
+    adjacentNodesWithProperties = newArray;
+    return oldsize - newSize;
+  }
+
 }

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/OdbNode.java
@@ -591,7 +591,7 @@ public abstract class OdbNode implements Vertex {
   /**
    * Trims the node to save storage: shrinks overallocations
    * */
-  public synchronized int trim(){
+  public synchronized long trim(){
     int newSize = 0;
     for(int offsetPos = 0; 2*offsetPos < edgeOffsets.length(); offsetPos++){
       int length = blockLength(offsetPos);
@@ -609,7 +609,7 @@ public abstract class OdbNode implements Vertex {
     }
     int oldsize = adjacentNodesWithProperties.length;
     adjacentNodesWithProperties = newArray;
-    return oldsize - newSize;
+    return (long)newSize + ( ((long)oldsize) << 32);
   }
 
   public final boolean isDirty() {

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeDeserializer.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeDeserializer.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class NodeDeserializer {
   private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -27,13 +28,13 @@ public class NodeDeserializer {
   private final Map<Integer, NodeFactory> nodeFactoryByLabelId;
   private int deserializedCount = 0;
   private long deserializationTimeSpentNanos = 0;
-  private THashMap<String, String> interner;
+  private ConcurrentHashMap<String, String> interner;
 
 
   public NodeDeserializer(OdbGraph graph, Map<Integer, NodeFactory> nodeFactoryByLabelId) {
     this.graph = graph;
     this.nodeFactoryByLabelId = nodeFactoryByLabelId;
-    this.interner = new THashMap<String, String>();
+    this.interner = new ConcurrentHashMap<String, String>();
   }
 
   private final String intern(String s){

--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeDeserializer.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/NodeDeserializer.java
@@ -44,16 +44,7 @@ public class NodeDeserializer {
 
 
   public final OdbNode deserialize(byte[] bytes) throws IOException {
-    // todo: benchmark that this is < 100 ns of overhead
-    // depends on CPU / uCode / hypervisor / OS kernel / java config.
-    // AFAIU this is a syscall on linux, so may be slowish in the cloud (recent spectre/meltdown mitigations)
-
-    // Alternative 1: Use JNI to call a small __asm__ rdtsc function.
-    //  Downsides: -Need assembler in toolchain (or C compiler if we are lazy),
-    //  -bites us when we want to run on windows / POWER,
-    //  -needs a little handling in case we are preempted and rescheduled
-
-    // Alternative 2: Include surrounding code in timing, i.e. only call system.nanoTime() every 1<<17 invocations
+    // todo: only time when some config is set
 
     long start = System.nanoTime();
     if (null == bytes)

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/OdbNodeTest.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/OdbNodeTest.java
@@ -52,6 +52,12 @@ public class OdbNodeTest {
       TestEdge testEdge = (TestEdge) e;
       assertEquals(Long.valueOf(99), testEdge.longProperty());
 
+      //trim test
+      assertEquals(2, ((NodeRef)v1).get().trim());
+      assertEquals(0, ((NodeRef)v1).get().trim());
+      assertEquals(2, ((NodeRef)v0).get().trim());
+      assertEquals(0, ((NodeRef)v0).get().trim());
+
       // vertex traversals
       assertEquals(1, __(v0).out().toList().size());
       assertEquals(0, __(v0).out("otherLabel").toList().size());

--- a/tinkerpop3/src/test/java/io/shiftleft/overflowdb/OdbNodeTest.java
+++ b/tinkerpop3/src/test/java/io/shiftleft/overflowdb/OdbNodeTest.java
@@ -53,10 +53,10 @@ public class OdbNodeTest {
       assertEquals(Long.valueOf(99), testEdge.longProperty());
 
       //trim test
-      assertEquals(2, ((NodeRef)v1).get().trim());
-      assertEquals(0, ((NodeRef)v1).get().trim());
-      assertEquals(2, ((NodeRef)v0).get().trim());
-      assertEquals(0, ((NodeRef)v0).get().trim());
+      assertEquals(2 + (((long)4)<<32), ((NodeRef)v1).get().trim());
+      assertEquals(2 + (((long)2)<<32), ((NodeRef)v1).get().trim());
+      assertEquals(2 + (((long)4)<<32), ((NodeRef)v0).get().trim());
+      assertEquals(2 + (((long)2)<<32), ((NodeRef)v0).get().trim());
 
       // vertex traversals
       assertEquals(1, __(v0).out().toList().size());


### PR DESCRIPTION
This adds API for trimming overallocations. Intention is to run this as a final enhancement pass. @mpollmeier do we need to set a dirty flag on this?

Further, the timing code was silly (time in milliseconds for node deserialization -- if this is average > 1 ms, then we can throw away the code and start again). However, do we really want these semantics? I.e. do we really want to exclude the time for extracting the `bytes[]` buffer from the timing? Speed of nanoTime needs to be tested in our actual deployment, because it may well depend on whatever $cloud_provider is doing. As commented, I would prefer a small assembly file that we build into shared library and call with JNI (afaiu we only care about x86_64 with linux / windows / macos).

Further, added string interning on deserialization. Somebody needs to intern these strings, and g1gc only interns the buffers, not the String objects.

This ain't threadsafe, but deserialization should not be multithreaded anyway.

