### PR TITLE
moving away from tinkerpop graph api (1/?)

### DIFF
--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/NodeRef.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/NodeRef.java
@@ -117,7 +117,7 @@ public abstract class NodeRef<N extends OdbNode> implements Vertex {
   }
 
   @Override
-  public Graph graph() {
+  public OdbGraph graph() {
     return graph;
   }
 


### PR DESCRIPTION
* return OdbGraph specifically
* OdbGraph.addNode (replacement of tinkerpop's `addVertex`)