### PR TITLE
explicitly commit on close

### DIFF
--- a/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/OdbStorage.java
+++ b/tinkerpop3/src/main/java/io/shiftleft/overflowdb/storage/OdbStorage.java
@@ -97,7 +97,10 @@ public class OdbStorage implements AutoCloseable {
   public void close() {
     closed = true;
     logger.info("closing " + getClass().getSimpleName());
-    if (mvstore != null) mvstore.close();
+    if (mvstore != null) {
+      mvstore.commit();
+      mvstore.close();
+    }
     if (!doPersist) mvstoreFile.delete();
   }
 


### PR DESCRIPTION
this probably doesn't make a difference, since `commit` is called
internally on close, but doesn't harm either.