### PR TITLE
move PropertyKey to root package

### DIFF
--- a/traversal/src/main/scala/io/shiftleft/overflowdb/PropertyKey.scala
+++ b/traversal/src/main/scala/io/shiftleft/overflowdb/PropertyKey.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.overflowdb.traversal
+package io.shiftleft.overflowdb
 
 case class PropertyKey[A](name: String) {
   def ->(value: A): PropertyKeyValue[A] = PropertyKeyValue(this, value)

--- a/traversal/src/main/scala/io/shiftleft/overflowdb/traversal/NodeTraversal.scala
+++ b/traversal/src/main/scala/io/shiftleft/overflowdb/traversal/NodeTraversal.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.overflowdb.traversal
 
 import io.shiftleft.overflowdb.traversal.help.Doc
-import io.shiftleft.overflowdb.{NodeRef, OdbEdge}
+import io.shiftleft.overflowdb.{NodeRef, OdbEdge, PropertyKey, PropertyKeyValue}
 import org.apache.tinkerpop.gremlin.structure.Direction
 
 class NodeTraversal[A <: NodeRef[_]](val traversal: Traversal[A]) extends AnyVal {

--- a/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/gratefuldead/Artist.scala
+++ b/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/gratefuldead/Artist.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.overflowdb.traversal.testdomains.gratefuldead
 
-import io.shiftleft.overflowdb.traversal.{NodeRefOps, PropertyKey, Traversal}
-import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph}
+import io.shiftleft.overflowdb.traversal.{NodeRefOps, Traversal}
+import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph, PropertyKey}
 
 import scala.jdk.CollectionConverters._
 

--- a/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/gratefuldead/Song.scala
+++ b/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/gratefuldead/Song.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.overflowdb.traversal.testdomains.gratefuldead
 
 import io.shiftleft.overflowdb.traversal.testdomains.gratefuldead.Artist.LabelId
-import io.shiftleft.overflowdb.traversal.{NodeRefOps, PropertyKey, Traversal}
-import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph}
+import io.shiftleft.overflowdb.traversal.{NodeRefOps, Traversal}
+import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph, PropertyKey}
 
 import scala.jdk.CollectionConverters._
 

--- a/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/hierarchical/Car.scala
+++ b/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/hierarchical/Car.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.overflowdb.traversal.testdomains.hierarchical
 
-import io.shiftleft.overflowdb.traversal.{NodeRefOps, PropertyKey, Traversal}
-import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph}
+import io.shiftleft.overflowdb.traversal.{NodeRefOps, Traversal}
+import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph, PropertyKey}
 
 import scala.jdk.CollectionConverters._
 

--- a/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/hierarchical/Elephant.scala
+++ b/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/hierarchical/Elephant.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.overflowdb.traversal.testdomains.hierarchical
 
-import io.shiftleft.overflowdb.traversal.{NodeRefOps, PropertyKey, Traversal}
-import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph}
+import io.shiftleft.overflowdb.traversal.{NodeRefOps, Traversal}
+import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph, PropertyKey}
 
 import scala.jdk.CollectionConverters._
 

--- a/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/simple/Thing.scala
+++ b/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/testdomains/simple/Thing.scala
@@ -1,7 +1,8 @@
 package io.shiftleft.overflowdb.traversal.testdomains.simple
 
-import io.shiftleft.overflowdb.traversal.{NodeRefOps, PropertyKey, Traversal}
-import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph}
+import io.shiftleft.overflowdb.traversal.{NodeRefOps, Traversal}
+import io.shiftleft.overflowdb.{NodeFactory, NodeLayoutInformation, NodeRef, OdbGraph, PropertyKey}
+
 import scala.jdk.CollectionConverters._
 
 class Thing(graph: OdbGraph, id: Long) extends NodeRef[ThingDb](graph, id) with NodeRefOps[Thing] {


### PR DESCRIPTION
it's not specific to traversal, just happens to be a scala case class, and
there's currently no better subproject