### PR TITLE
Revert "upgrade mvstore with a few potentially relevant fixes (#94)"

### DIFF
--- a/tinkerpop3/build.sbt
+++ b/tinkerpop3/build.sbt
@@ -7,7 +7,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-lang3" % "3.9",
   "net.sf.trove4j" % "core" % "3.1.0",
   "org.msgpack" % "msgpack-core" % "0.8.17",
-  "com.h2database" % "h2-mvstore" % "1.4.200",
+  "com.h2database" % "h2-mvstore" % "1.4.199",
   "org.apache.tinkerpop" % "gremlin-test" % tinkerpopVersion % Test,
   "com.novocode" % "junit-interface" % "0.11" % Test,
   "org.slf4j" % "slf4j-simple" % "1.7.28" % Test,


### PR DESCRIPTION
This reverts commit caa5bcff45d4411641a35edf7a38ee5da4ed7816.

Reverting because we've seen more of the ominous chunking issues with mvstore recently. 