### PR TITLE
tinkerpopperise step names for more consistency: hasLabel/hasId

### DIFF
--- a/traversal/src/main/scala/io/shiftleft/overflowdb/traversal/ElementTraversal.scala
+++ b/traversal/src/main/scala/io/shiftleft/overflowdb/traversal/ElementTraversal.scala
@@ -13,7 +13,7 @@ class ElementTraversal[E <: OdbElement](val traversal: Traversal[E]) extends Any
    * Note: do not use as the first step in a traversal, e.g. `traversalSource.all.label(value)`.
    * Use `traversalSource.withLabel` instead, it is much faster
    * TODO: make the above an automatic optimisation */
-  def label(value: String): Traversal[E] =
+  def hasLabel(value: String): Traversal[E] =
     traversal.filter(_.label == value)
 
   def has(key: PropertyKey[_]): Traversal[E] = has(key.name)

--- a/traversal/src/main/scala/io/shiftleft/overflowdb/traversal/NodeTraversal.scala
+++ b/traversal/src/main/scala/io/shiftleft/overflowdb/traversal/NodeTraversal.scala
@@ -11,7 +11,7 @@ class NodeTraversal[E <: NodeRef[_]](val traversal: Traversal[E]) extends AnyVal
 
   /** Note: do not use as the first step in a traversal, e.g. `traversalSource.all.id(value)`.
    * Use `traversalSource.withId` instead, it is much faster */
-  def id(value: Long): Traversal[E] =
+  def hasId(value: Long): Traversal[E] =
     traversal.filter(_.id == value)
 
   /** follow outgoing edges to adjacent nodes */

--- a/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/GenericGraphTraversalTests.scala
+++ b/traversal/src/test/scala/io/shiftleft/overflowdb/traversal/GenericGraphTraversalTests.scala
@@ -31,14 +31,14 @@ class GenericGraphTraversalTests extends WordSpec with Matchers {
 
   "filter steps" can {
     "filter by id" in {
-      graph.V.id(centerNode.id).property(Thing.Properties.Name).toList shouldBe List("Center")
+      graph.V.hasId(centerNode.id).property(Thing.Properties.Name).toList shouldBe List("Center")
     }
 
     "filter by label" in {
-      graph.V.label(Thing.Label).size shouldBe 8
-      graph.V.label(nonExistingLabel).size shouldBe 0
-      graph.E.label(Connection.Label).size shouldBe 7
-      graph.E.label(nonExistingLabel).size shouldBe 0
+      graph.V.hasLabel(Thing.Label).size shouldBe 8
+      graph.V.hasLabel(nonExistingLabel).size shouldBe 0
+      graph.E.hasLabel(Connection.Label).size shouldBe 7
+      graph.E.hasLabel(nonExistingLabel).size shouldBe 0
     }
 
     "filter by property key" in {


### PR DESCRIPTION
label(x) -> hasLabel(x)
id(x) -> hasId(x)

I changed my opinion on these because the latter versions are more
consistent with e.g. the property filter steps: `property(key)` is
a property lookup step, and not a filter step, which is why we have the
`hasXX` steps in the first place.