### PR TITLE
.dedup step (like distinct, unique, ...)

### DIFF
--- a/tinkerpop3/src/main/java/overflowdb/NodeRef.java
+++ b/tinkerpop3/src/main/java/overflowdb/NodeRef.java
@@ -8,6 +8,7 @@ import overflowdb.tp3.Converters;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -145,16 +146,12 @@ public abstract class NodeRef<N extends OdbNode> implements Vertex, Node {
 
   @Override
   public int hashCode() {
-    return id().hashCode();
+    return Objects.hash(id2(), label());
   }
 
   @Override
   public boolean equals(final Object obj) {
-    if (obj instanceof Node) {
-      return id().equals(((Node) obj).id());
-    } else {
-      return false;
-    }
+    return (obj instanceof Node) && id2() == ((Node) obj).id2();
   }
 
   @Override

--- a/tinkerpop3/src/main/java/overflowdb/OdbNode.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbNode.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -811,4 +812,13 @@ public abstract class OdbNode implements Vertex, Node {
     return keyValuesArray;
   }
 
+  @Override
+  public int hashCode() {
+    return Objects.hash(id2(), label());
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    return (obj instanceof OdbNode) && id2() == ((OdbNode) obj).id2();
+  }
 }

--- a/traversal/src/main/scala/overflowdb/traversal/DedupBehaviour.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/DedupBehaviour.scala
@@ -1,0 +1,70 @@
+package overflowdb.traversal
+
+import DedupBehaviour.ComparisonStyle
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+trait DedupBehaviour {
+  val comparisonStyle: ComparisonStyle.Value
+}
+
+object DedupBehaviour {
+    object ComparisonStyle extends Enumeration {
+      type ComparisonStyle = Value
+      val HashAndEquals, HashOnly = Value
+    }
+
+    def noop(builder: DedupBehaviour.Builder): Builder = builder
+
+    class Builder {
+      private[this] var _comparisonStyle: ComparisonStyle.Value = ComparisonStyle.HashAndEquals
+
+      /* only compare the hashes when deduplicating elements. depending on the element type this can lead to
+      configure search algorithm to go "breadth first", rather than the default "depth first" */
+      def hashComparisonOnly: Builder = {
+        _comparisonStyle = ComparisonStyle.HashOnly
+        this
+      }
+
+      private[traversal] def build: DedupBehaviour =
+        new DedupBehaviour {
+          override val comparisonStyle = _comparisonStyle
+        }
+    }
+}
+
+class DedupByHashIterator[A](elements: IterableOnce[A]) extends Iterator[A] {
+  private var _next: A = _
+  private var _nextLoaded = false
+  private val hashesOfSeenElements = mutable.Set.empty[Int]
+
+  @tailrec
+  final override def hasNext: Boolean = {
+    if (_nextLoaded) {
+      true
+    } else if (elements.isEmpty) {
+      false
+    } else {
+      val nextElement = elements.next
+      val nextElementHash = nextElement.hashCode
+      if (hashesOfSeenElements.contains(nextElementHash)) {
+        hasNext
+      } else {
+        _next = nextElement
+        _nextLoaded = true
+        hashesOfSeenElements.add(nextElementHash)
+        true
+      }
+    }
+  }
+
+  override def next(): A = {
+    if (hasNext) {
+      _nextLoaded = false
+      _next
+    } else {
+      throw new NoSuchElementException("next on empty iterator")
+    }
+  }
+}

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -46,6 +46,24 @@ class Traversal[A](elements: IterableOnce[A])
   def cast[B]: Traversal[B] =
     new Traversal[B](elements.iterator.map(_.asInstanceOf[B]))
 
+  /** Deduplicate elements of this traversal - a.k.a. distinct, unique, ...
+   * Preserves order and laziness semantics of Traversal.
+   *
+   * By default, it's determining duplicates based on equals and hashCode, just like java.util.Set.
+   * While that's usually fine, be aware that it has to maintain references to those elements even after they've been
+   * traversed, i.e. they can't be garbage collected while the traversal has not yet completed. In other words, the
+   * semantics are like LazyList, and not like Iterator.
+   *
+   * It can be configured to determine duplicates based on hashCode only instead, in which case elements can get freed.
+   *
+   * @example
+   * {{{
+   * .dedup
+   * .dedup(_.hashComparisonOnly)
+   * }}}
+   *
+   * see TraversalTests.scala
+   */
   def dedup(implicit behaviourBuilder: DedupBehaviour.Builder => DedupBehaviour.Builder = DedupBehaviour.noop _)
     : Traversal[A] = {
      behaviourBuilder(new DedupBehaviour.Builder).build.comparisonStyle match {


### PR DESCRIPTION
Deduplicate elements of this traversal - a.k.a. distinct, unique, ...
Preserves order and laziness semantics of Traversal.

By default, it's determining duplicates based on equals and hashCode, just like java.util.Set.
While that's usually fine, be aware that it has to maintain references to those elements even after they've been
traversed, i.e. they can't be garbage collected while the traversal has not yet completed. In other words, the
semantics are like LazyList, and not like Iterator.

It can be configured to determine duplicates based on hashCode only instead, in which case elements can get freed.

```
.dedup
.dedup(_.hashComparisonOnly)
```