### PR TITLE
rename nodesByLabel -> nodes

### DIFF
--- a/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
@@ -368,7 +368,7 @@ public final class OdbGraph implements Graph {
     }
   }
 
-  public Iterator<Node> nodesByLabel(final String label) {
+  public Iterator<Node> nodes(final String label) {
     final Set<NodeRef> nodes = nodesByLabel.get(label);
     if (nodes != null)
       return IteratorUtils.map(nodes.iterator(), node -> node);
@@ -376,7 +376,7 @@ public final class OdbGraph implements Graph {
       return EmptyIterator.INSTANCE;
   }
 
-  public Iterator<Node> nodesByLabel(final String... labels) {
+  public Iterator<Node> nodes(final String... labels) {
     final MultiIterator<Node> multiIterator = new MultiIterator<>();
     for (String label : labels) {
       addNodesToMultiIterator(multiIterator, label);
@@ -384,7 +384,7 @@ public final class OdbGraph implements Graph {
     return multiIterator;
   }
 
-  public Iterator<Node> nodesByLabel(final Set<String> labels) {
+  public Iterator<Node> nodes(final Set<String> labels) {
     final MultiIterator<Node> multiIterator = new MultiIterator<>();
     for (String label : labels) {
       addNodesToMultiIterator(multiIterator, label);
@@ -392,7 +392,7 @@ public final class OdbGraph implements Graph {
     return multiIterator;
   }
 
-  public Iterator<Node> nodesByLabel(final P<String> labelPredicate) {
+  public Iterator<Node> nodes(final P<String> labelPredicate) {
     final MultiIterator<Node> multiIterator = new MultiIterator<>();
     for (String label : nodesByLabel.keySet()) {
       if (labelPredicate.test(label)) {

--- a/tinkerpop3/src/main/java/overflowdb/tp3/optimizations/OdbGraphStep.java
+++ b/tinkerpop3/src/main/java/overflowdb/tp3/optimizations/OdbGraphStep.java
@@ -61,7 +61,7 @@ public final class OdbGraphStep<S, E extends Element> extends GraphStep<S, E> im
     else if (hasLabelContainer.isPresent()) {
       P<String> hasLabelPredicate = (P<String>) hasLabelContainer.get().getPredicate();
       // unfortunately TP3 api doesn't seem to find out if it's the `Compare.eq` bipredicate, so we can optimise single-label lookups
-      return graph.nodesByLabel(hasLabelPredicate);
+      return graph.nodes(hasLabelPredicate);
     } else {
       if (indexedContainer == null) return this.iteratorList(graph.vertices());
       else {

--- a/tinkerpop3/src/test/java/overflowdb/OdbNodeTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/OdbNodeTest.java
@@ -484,7 +484,7 @@ public class OdbNodeTest {
       assertNodeCount(2, graph);
       assertEdgeCount(2, graph);
 
-      assertSize(2, graph.nodesByLabel(Song.label));
+      assertSize(2, graph.nodes(Song.label));
       // TODO move to tinkerpop-subproject once it's factored out
       assertEquals(new Long(2), graph.traversal().E().hasLabel(FollowedBy.LABEL).count().next());
     }

--- a/traversal/src/main/scala/overflowdb/traversal/TraversalSource.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/TraversalSource.scala
@@ -16,5 +16,5 @@ abstract class TraversalSource(graph: OdbGraph) {
     Traversal(graph.nodes(ids: _*))
 
   def label(label: String): Traversal[Node] =
-    Traversal(graph.nodesByLabel(label))
+    Traversal(graph.nodes(label))
 }


### PR DESCRIPTION
node ids are of type `Long`, so `nodes(String)` is pretty obvious to be
filtering on the label