### PR TITLE
remove 'traversal already exhausted' warning

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -143,29 +143,10 @@ class Traversal[A](elements: IterableOnce[A])
     flatMap(RepeatStep(_repeatTraversal, behaviour))
   }
 
-  override val iterator: Iterator[A] = new Iterator[A] {
-    private val wrappedIter = elements.iterator
-    private var isExhausted = false
-
-    override def hasNext: Boolean = {
-      val _hasNext = wrappedIter.hasNext
-      if (!_hasNext) {
-        if (isExhausted)
-          Traversal.logger.warn("Traversal already exhausted")
-        else isExhausted = true
-      }
-      _hasNext
-    }
-
-    override def next(): A = wrappedIter.next
-  }
-
-  override def toString = getClass.getSimpleName
-
-  override def iterableFactory: IterableFactory[Traversal] = Traversal
-
+  override val iterator: Iterator[A] = elements.iterator
   override def toIterable: Iterable[A] = Iterable.from(elements)
-
+  override def iterableFactory: IterableFactory[Traversal] = Traversal
+  override def toString = getClass.getSimpleName
   override protected def coll: Traversal[A] = this
 }
 

--- a/traversal/src/test/scala/overflowdb/traversal/TraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/TraversalTests.scala
@@ -10,11 +10,11 @@ class TraversalTests extends WordSpec with Matchers {
   "can only be iterated once" in {
     val one = Traversal.fromSingle("one")
     one.size shouldBe 1
-    one.size shouldBe 0 // logs a warning (not tested here)
+    one.size shouldBe 0
 
     val empty = Traversal(Nil)
     empty.size shouldBe 0
-    empty.size shouldBe 0 // logs a warning (not tested here)
+    empty.size shouldBe 0
   }
 
   "perform sideEffect" should {


### PR DESCRIPTION
The idea was to warn the user that a traversal cannot be executed twice,
but unfortunately I didn't find a better place than to put this check in
`hasNext`.
There are plenty of legitimate reasons to check `hasNext` more than once,
leading to many of these warnings being logged e.g. during
codepropertygraph/test, which only causes confusion.