### PR TITLE
filter elements by a property with arbitrary predicate - and predefine some in `P`

### DIFF
--- a/traversal/src/main/scala/overflowdb/Property.scala
+++ b/traversal/src/main/scala/overflowdb/Property.scala
@@ -3,7 +3,8 @@ package overflowdb
 case class PropertyKey[A](name: String) {
   def ->(value: A): Property[A] = Property(this, value)
 
-  def of(value: A): Property[A] = Property(this, value)
+  def where(predicate: A => Boolean): PropertyPredicate[A] =
+    new PropertyPredicate[A](this, predicate)
 }
 
 case class Property[A](key: PropertyKey[A], value: A)
@@ -12,3 +13,6 @@ object Property {
   def apply[A](key: String, value: A): Property[A] =
     Property[A](PropertyKey[A](key), value)
 }
+
+class PropertyPredicate[A](val key: PropertyKey[A], val predicate: A => Boolean)
+

--- a/traversal/src/main/scala/overflowdb/traversal/ElementTraversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/ElementTraversal.scala
@@ -22,17 +22,32 @@ class ElementTraversal[E <: OdbElement](val traversal: Traversal[E]) extends Any
   /** Filter elements by existence of property (irrespective of value) */
   def has(key: PropertyKey[_]): Traversal[E] = has(key.name)
 
+  /** Filter elements by (non-)existence of property (irrespective of value) */
+  def hasNot(key: PropertyKey[_]): Traversal[E] = hasNot(key.name)
+
   /** Filter elements by existence of property (irrespective of value) */
   def has(name: String): Traversal[E] =
     traversal.filter(_.property2(name) != null)
+
+  /** Filter elements by (non-)existence of property (irrespective of value) */
+  def hasNot(name: String): Traversal[E] =
+    traversal.filter(_.property2(name) == null)
 
   /** Filter elements by property value */
   def has[A](keyValue: Property[A]): Traversal[E] =
     has[A](keyValue.key, keyValue.value)
 
   /** Filter elements by property value */
+  def hasNot[A](keyValue: Property[A]): Traversal[E] =
+    hasNot[A](keyValue.key, keyValue.value)
+
+  /** Filter elements by property value */
   def has[A](key: PropertyKey[A], value: A): Traversal[E] =
     traversal.filter(_.property2(key.name) == value)
+
+  /** Filter elements by property value */
+  def hasNot[A](key: PropertyKey[A], value: A): Traversal[E] =
+    traversal.filter(_.property2(key.name) != value)
 
   /** Filter elements by property with given predicate.
    * @example from GenericGraphTraversalTest
@@ -49,19 +64,20 @@ class ElementTraversal[E <: OdbElement](val traversal: Traversal[E]) extends Any
   def has[A](propertyPredicate: PropertyPredicate[A]): Traversal[E] =
     traversal.filter(element => propertyPredicate.predicate(element.property(propertyPredicate.key)))
 
-  def hasNot(key: PropertyKey[_]): Traversal[E] = hasNot(key.name)
-
-  def hasNot(name: String): Traversal[E] =
-    traversal.filter(_.property2(name) == null)
-
-  def hasNot[A](keyValue: Property[A]): Traversal[E] =
-    hasNot[A](keyValue.key, keyValue.value)
-
-  def hasNot[A](key: PropertyKey[A], value: A): Traversal[E] =
-    traversal.filter(_.property2(key.name) != value)
-
-  def hasNot[A](key: PropertyKey[A], predicate: A => Boolean): Traversal[E] =
-    traversal.filter(element => predicate(element.property2(key.name)))
+  /** Filter elements by property with given predicate.
+   * @example from GenericGraphTraversalTest
+   * {{{
+   * .hasNot(Name.where(_.endsWith("1")))
+   * .hasNot(Name.where(_.matches("[LR].")))
+   * .hasNot(Name.where(P.eq("R1")))
+   * .hasNot(Name.where(P.neq("R1")))
+   * .hasNot(Name.where(P.within(Set("L1", "L2"))))
+   * .hasNot(Name.where(P.within("L1", "L2", "L3")))
+   * .hasNot(Name.where(P.matches("[LR].")))
+   * }}}
+   */
+  def hasNot[A](propertyPredicate: PropertyPredicate[A]): Traversal[E] =
+    traversal.filterNot(element => propertyPredicate.predicate(element.property(propertyPredicate.key)))
 
   def property[A](key: PropertyKey[A]): Traversal[A] =
     property(key.name)

--- a/traversal/src/main/scala/overflowdb/traversal/filter/P.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/filter/P.scala
@@ -8,12 +8,19 @@ object P {
   def neq[A](a: A): A => Boolean =
     a.!=
 
+  def regexMatches(regex: String): String => Boolean =
+    _.matches(regex)
+
   def within[A](values: Set[A]): A => Boolean =
     values.contains
 
   def within[A](values: A*): A => Boolean =
     within(values.to(Set))
 
-  def matches(regex: String): String => Boolean =
-    _.matches(regex)
+  def without[A](values: Set[A]): A => Boolean =
+    { a: A => !values.contains(a) }
+
+  def without[A](values: A*): A => Boolean =
+    without(values.to(Set))
+
 }

--- a/traversal/src/main/scala/overflowdb/traversal/filter/P.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/filter/P.scala
@@ -1,0 +1,19 @@
+package overflowdb.traversal.filter
+
+/** commonly used predicates e.g. for Traversal.has|hasNot|is steps */
+object P {
+  def eq[A](a: A): A => Boolean =
+    a.==
+
+  def neq[A](a: A): A => Boolean =
+    a.!=
+
+  def within[A](values: Set[A]): A => Boolean =
+    values.contains
+
+  def within[A](values: A*): A => Boolean =
+    within(values.to(Set))
+
+  def matches(regex: String): String => Boolean =
+    _.matches(regex)
+}

--- a/traversal/src/test/scala/overflowdb/traversal/GenericGraphTraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/GenericGraphTraversalTests.scala
@@ -57,16 +57,28 @@ class GenericGraphTraversalTests extends WordSpec with Matchers {
     "filter by property key/value" in {
       graph.V.has(Name, "R1").size shouldBe 1
       graph.V.has(Name -> "R1").size shouldBe 1
-      graph.V.has(Name.where(_.endsWith("1"))).size shouldBe 2
-      graph.V.has(Name.where(_.matches("[LR]."))).size shouldBe 7
       graph.V.has(Name.where(P.eq("R1"))).size shouldBe 1
+      graph.V.has(Name.where(P.regexMatches("[LR]."))).size shouldBe 7
+      graph.V.has(Name.where(_.matches("[LR]."))).size shouldBe 7
       graph.V.has(Name.where(P.neq("R1"))).size shouldBe 7
       graph.V.has(Name.where(P.within(Set("L1", "L2")))).size shouldBe 2
       graph.V.has(Name.where(P.within("L1", "L2", "L3"))).size shouldBe 3
-      graph.V.has(Name.where(P.matches("[LR]."))).size shouldBe 7
-
-      graph.V.hasNot(Name -> "R1").size shouldBe 7
+      graph.V.has(Name.where(P.without(Set("L1", "L2")))).size shouldBe 6
+      graph.V.has(Name.where(P.without("L1", "L2", "L3"))).size shouldBe 5
+      graph.V.has(Name.where(_.endsWith("1"))).size shouldBe 2
       graph.E.has(Distance -> 10).size shouldBe 2
+
+      graph.V.hasNot(Name, "R1").size shouldBe 7
+      graph.V.hasNot(Name -> "R1").size shouldBe 7
+      graph.V.hasNot(Name.where(P.eq("R1"))).size shouldBe 7
+      graph.V.hasNot(Name.where(P.regexMatches("[LR]."))).size shouldBe 1
+      graph.V.hasNot(Name.where(_.matches("[LR]."))).size shouldBe 1
+      graph.V.hasNot(Name.where(P.neq("R1"))).size shouldBe 1
+      graph.V.hasNot(Name.where(P.within(Set("L1", "L2")))).size shouldBe 6
+      graph.V.hasNot(Name.where(P.within("L1", "L2", "L3"))).size shouldBe 5
+      graph.V.hasNot(Name.where(P.without(Set("L1", "L2")))).size shouldBe 2
+      graph.V.hasNot(Name.where(P.without("L1", "L2", "L3"))).size shouldBe 3
+      graph.V.hasNot(Name.where(_.endsWith("1"))).size shouldBe 6
       graph.E.hasNot(Distance -> 10).size shouldBe 5
     }
 


### PR DESCRIPTION

```
/** Filter elements by property with given predicate.
   * @example from GenericGraphTraversalTest
   * {{{
   * .has(Name.where(_.endsWith("1")))
   * .has(Name.where(_.matches("[LR].")))
   * .has(Name.where(P.eq("R1")))
   * .has(Name.where(P.neq("R1")))
   * .has(Name.where(P.within(Set("L1", "L2"))))
   * .has(Name.where(P.within("L1", "L2", "L3")))
   * .has(Name.where(P.matches("[LR].")))
   * }}}
   */
  def has[A](propertyPredicate: PropertyPredicate[A]): Traversal[E]

  /** Filter elements by property with given predicate.
   * @example from GenericGraphTraversalTest
   * {{{
   * .hasNot(Name.where(_.endsWith("1")))
   * .hasNot(Name.where(_.matches("[LR].")))
   * .hasNot(Name.where(P.eq("R1")))
   * .hasNot(Name.where(P.neq("R1")))
   * .hasNot(Name.where(P.within(Set("L1", "L2"))))
   * .hasNot(Name.where(P.within("L1", "L2", "L3")))
   * .hasNot(Name.where(P.matches("[LR].")))
   * }}}
   */
  def hasNot[A](propertyPredicate: PropertyPredicate[A]): Traversal[E]
```