### PR TITLE
use only id for hashCode - as it used to be

### DIFF
--- a/tinkerpop3/src/main/java/overflowdb/NodeRef.java
+++ b/tinkerpop3/src/main/java/overflowdb/NodeRef.java
@@ -146,7 +146,7 @@ public abstract class NodeRef<N extends OdbNode> implements Vertex, Node {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id2(), label());
+    return Objects.hash(id2());
   }
 
   @Override

--- a/tinkerpop3/src/main/java/overflowdb/OdbNode.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbNode.java
@@ -814,7 +814,7 @@ public abstract class OdbNode implements Vertex, Node {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id2(), label());
+    return Objects.hash(id2());
   }
 
   @Override


### PR DESCRIPTION
I initially changed it to include `label` for the dedup step, but this
has become redundant now.