### PR TITLE
coalesce step

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -196,6 +196,15 @@ class Traversal[A](elements: IterableOnce[A])
       }
     }
 
+  def coalesce[NewEnd](options: (Traversal[A] => Traversal[NewEnd])*): Traversal[NewEnd] =
+    flatMap { a: A =>
+      val x = options.find { trav =>
+        trav(Traversal.fromSingle(a)).hasNext
+      }.getOrElse{_: Traversal[A] => Traversal.empty[NewEnd]}
+      val y = x(Traversal.fromSingle(a))
+      y
+    }
+
   override val iterator: Iterator[A] = elements.iterator
   override def toIterable: Iterable[A] = Iterable.from(elements)
   override def iterableFactory: IterableFactory[Traversal] = Traversal

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -198,11 +198,9 @@ class Traversal[A](elements: IterableOnce[A])
 
   def coalesce[NewEnd](options: (Traversal[A] => Traversal[NewEnd])*): Traversal[NewEnd] =
     flatMap { a: A =>
-      val x = options.find { trav =>
-        trav(Traversal.fromSingle(a)).hasNext
-      }.getOrElse{_: Traversal[A] => Traversal.empty[NewEnd]}
-      val y = x(Traversal.fromSingle(a))
-      y
+      options.iterator.map(_.apply(Traversal.fromSingle(a))).collectFirst {
+        case option if option.nonEmpty => option
+      }.getOrElse(Traversal.empty)
     }
 
   override val iterator: Iterator[A] = elements.iterator

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -196,6 +196,18 @@ class Traversal[A](elements: IterableOnce[A])
       }
     }
 
+  /** Branch step: evaluates the provided traversals in order and returns the first traversal that emits at least one element.
+   *
+   * @example
+   * {{{
+   *  .coalesce(
+   *    _.out("label1"),
+   *    _.in("label2"),
+   *    _.in("label3")
+   *  )
+   * }}}
+   * @see LogicalStepsTests
+   */
   def coalesce[NewEnd](options: (Traversal[A] => Traversal[NewEnd])*): Traversal[NewEnd] =
     flatMap { a: A =>
       options.iterator.map(_.apply(Traversal.fromSingle(a))).collectFirst {

--- a/traversal/src/test/scala/overflowdb/traversal/LogicalStepsTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/LogicalStepsTests.scala
@@ -77,20 +77,6 @@ class LogicalStepsTests extends WordSpec with Matchers {
     }
   }
 
-  "foo" in {
-    import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.__
-    import org.apache.tinkerpop.gremlin.process.traversal.Traverser
-    import org.apache.tinkerpop.gremlin.structure.Vertex
-    import Thing.PropertyNames.Name
-    import scala.jdk.CollectionConverters._
-    def tp = graph.traversal.V(centerNode.id)
-    println(tp.coalesce().toList)
-    println(tp.coalesce(__()).toList)
-    println(tp.coalesce(__(), __()).toList)
-    println(tp.coalesce(__(), __().out()).toList)
-    println(tp.coalesce(__().out()).toList)
-  }
-
   "coalesce step takes arbitrary number of traversals and follows the first one that returns at least one element" in {
     centerTrav.coalesce(_.out).property(Name).toSet shouldBe Set("L1", "R1")
 


### PR DESCRIPTION
evaluates the provided traversals in order and returns the first traversal that emits at least one element.

```
.coalesce(
 _.out("label1"),
 _.in("label2"),
 _.in("label3")
)
```