### PR TITLE
replace trove collection with custom list for performance and memory usage

### DIFF
--- a/tinkerpop3/src/main/java/overflowdb/NodeRef.java
+++ b/tinkerpop3/src/main/java/overflowdb/NodeRef.java
@@ -299,4 +299,8 @@ public abstract class NodeRef<N extends OdbNode> implements Vertex, Node {
 
   // delegate methods end
 
+  @Override
+  public String toString() {
+    return getClass().getName() + "[label=" + label() + "; id=" + id + "]";
+  }
 }

--- a/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
@@ -382,7 +382,7 @@ public final class OdbGraph implements Graph {
   private final void addNodesToMultiIterator(final MultiIterator<Node> multiIterator, final String label) {
     final Set<Node> ret = nodes.nodesByLabel(label);
     if (ret != null) {
-      multiIterator.addIterator(IteratorUtils.map(ret.iterator(), node -> node));
+      multiIterator.addIterator(ret.iterator());
     }
   }
 

--- a/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Vector;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class OdbGraph implements Graph {
@@ -60,11 +59,12 @@ public final class OdbGraph implements Graph {
 
   private final GraphFeatures features = new GraphFeatures();
   protected final AtomicLong currentId = new AtomicLong(-1L);
-  //TODO make these `final`?
+  // TODO: make these `final`?
   // TODO: this collection is only growing - intermittently trim it, e.g. if many elements have been deleted, after a GC run - note: must reeindex nodeIndexByNodeId
   protected ArrayList<NodeRef> nodes;
   protected TLongIntMap nodeIndexByNodeId; //index into `nodes` array by node id
   protected THashMap<String, Set<NodeRef>> nodesByLabel;
+
   protected final GraphVariables variables = new GraphVariables();
   public final OdbIndexManager indexManager = new OdbIndexManager(this);
   private final OdbConfig config;
@@ -357,18 +357,11 @@ public final class OdbGraph implements Graph {
 
   /** Iterator over all nodes - alias for `nodes` */
   public Iterator<? extends Node> V() {
-//    return nodes();
     return nodes();
   }
 
   /** Iterator over all nodes */
   public final Iterator<? extends Node> nodes() {
-//    final Iterator<NodeRef> nodeRefIter = nodes.iterator();
-//    final ArrayList<Node> n1 = (ArrayList<Node>) nodes;
-    final ArrayList<? extends Node> n1 = nodes;
-//    return this.nodes.iterator();
-//    return null;
-//    return IteratorUtils.map(nodeRefIter, ref -> ref); // javac has humour
     return nodes.iterator();
   }
 

--- a/tinkerpop3/src/main/java/overflowdb/OdbIndexManager.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbIndexManager.java
@@ -1,8 +1,7 @@
 package overflowdb;
 
-import overflowdb.storage.OdbStorage;
-import org.apache.tinkerpop.gremlin.structure.Property;
 import org.h2.mvstore.MVMap;
+import overflowdb.storage.OdbStorage;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,10 +35,12 @@ public final class OdbIndexManager {
 
     dirtyFlags.put(propertyName, true);
 
-    graph.nodes.parallelStream()
-        .map(e -> new Object[]{e.property(propertyName), e})
-        .filter(a -> ((Property) a[0]).isPresent())
-        .forEach(a -> put(propertyName, ((Property) a[0]).value(), (NodeRef) a[1]));
+    graph.nodes.iterator().forEachRemaining(node -> {
+      Object value = node.property2(propertyName);
+      if (value != null) {
+        put(propertyName, value, (NodeRef) node);
+      }
+    });
   }
 
   private void checkPropertyName(String propertyName) {

--- a/tinkerpop3/src/main/java/overflowdb/OdbIndexManager.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbIndexManager.java
@@ -36,7 +36,7 @@ public final class OdbIndexManager {
 
     dirtyFlags.put(propertyName, true);
 
-    graph.nodes.valueCollection().parallelStream()
+    graph.nodes.parallelStream()
         .map(e -> new Object[]{e.property(propertyName), e})
         .filter(a -> ((Property) a[0]).isPresent())
         .forEach(a -> put(propertyName, ((Property) a[0]).value(), (NodeRef) a[1]));

--- a/tinkerpop3/src/main/java/overflowdb/OdbNode.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbNode.java
@@ -211,7 +211,7 @@ public abstract class OdbNode implements Vertex, Node {
       }
     }
 
-    ref.graph.removeNode(this);
+    ref.graph.remove(this);
 
     /* marking as dirty *after* we updated - if node gets serialized before we finish, it'll be marked as dirty */
     this.markAsDirty();

--- a/tinkerpop3/src/main/java/overflowdb/OdbNode.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbNode.java
@@ -203,7 +203,6 @@ public abstract class OdbNode implements Vertex, Node {
 
   @Override
   public void remove() {
-    OdbGraph graph = ref.graph;
     final List<Edge> edges = new ArrayList<>();
     bothE().forEachRemaining(edges::add);
     for (Edge edge : edges) {
@@ -211,11 +210,9 @@ public abstract class OdbNode implements Vertex, Node {
         edge.remove();
       }
     }
-    graph.indexManager.removeElement(ref);
-    graph.nodes.remove(ref.id);
-    graph.nodesByLabel.get(label()).remove(ref);
 
-    graph.storage.removeNode(ref.id);
+    ref.graph.removeNode(this);
+
     /* marking as dirty *after* we updated - if node gets serialized before we finish, it'll be marked as dirty */
     this.markAsDirty();
   }

--- a/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
+++ b/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
@@ -53,6 +53,7 @@ public class NodesList {
 
   /** store NodeRef in internal collections */
   public synchronized void add(NodeRef node) {
+    verifyUniqueId(node);
     int index = tryClaimEmptySlot();
     if (index == -1) {
       // no empty spot available - append to nodes array instead
@@ -64,6 +65,13 @@ public class NodesList {
     nodeIndexByNodeId.put(node.id, index);
     nodesByLabel(node.label()).add(node);
     size++;
+  }
+
+  private void verifyUniqueId(NodeRef node) {
+    if (nodeIndexByNodeId.containsKey(node.id)) {
+      NodeRef existingNode = nodeById(node.id);
+      throw new AssertionError("different Node with same id already exists in this NodesList: " + existingNode);
+    }
   }
 
   /** @return -1 if no available empty slots, otherwise the successfully claimed slot */

--- a/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
+++ b/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
@@ -106,6 +106,7 @@ public class NodesList {
     emptySlots.set(index);
     nodesByLabel.get(node.label()).remove(node);
     size--;
+    compactMaybe();
   }
 
   public int size() {
@@ -115,6 +116,16 @@ public class NodesList {
   private void ensureCapacity(int minCapacity) {
     if (nodes.length < minCapacity) grow(minCapacity);
   }
+
+  /** compact if there are many empty slots, and they make up >= 30% of the node array */
+  private void compactMaybe() {
+    final int emptyCount = emptySlots.cardinality();
+    if (emptyCount > 10000 &&
+        emptyCount * 100 / nodes.length >= 30) {
+      compact();
+    }
+  }
+
 
   /** trims down internal collections to just about the necessary size, in order to allow the remainder to be garbage collected */
   public void compact() {

--- a/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
+++ b/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
@@ -6,12 +6,13 @@ import gnu.trove.map.hash.THashMap;
 import gnu.trove.map.hash.TLongIntHashMap;
 import gnu.trove.set.hash.THashSet;
 import overflowdb.Node;
+import overflowdb.NodeRef;
+import overflowdb.OdbNode;
 
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -87,7 +88,12 @@ public class NodesList {
     int index = nodeIndexByNodeId.remove(node.id2());
     nodes[index] = null;
     emptySlots.set(index);
-    nodesByLabel.get(node.label()).remove(node);
+
+    NodeRef ref = node instanceof OdbNode
+        ? ((OdbNode) node).ref
+        : (NodeRef) node;
+    nodesByLabel.get(node.label()).remove(ref);
+
     size--;
     compactMaybe();
   }
@@ -114,19 +120,7 @@ public class NodesList {
   }
 
   public Iterator<Node> iterator() {
-    return new Iterator<Node>() {
-      // TODO copy array to avoid concurrent modification?
-      private int currIdx = 0;
-      @Override
-      public boolean hasNext() {
-        return currIdx < size;
-      }
-
-      @Override
-      public Node next() {
-        return nodes[currIdx++];
-      }
-    };
+    return Arrays.stream(nodes).filter(Objects::nonNull).iterator();
   }
 
   private void ensureCapacity(int minCapacity) {

--- a/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
+++ b/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
@@ -1,0 +1,72 @@
+package overflowdb.util;
+
+import gnu.trove.map.TLongIntMap;
+import gnu.trove.map.hash.THashMap;
+import gnu.trove.map.hash.TLongIntHashMap;
+import gnu.trove.set.hash.THashSet;
+import overflowdb.NodeRef;
+import overflowdb.OdbNode;
+
+import java.util.Set;
+
+// TODO: this collection is only growing - intermittently trim it, e.g. if many elements have been deleted, after a GC run - note: must reeindex nodeIndexByNodeId
+public class NodesList {
+  private NodeRef[] nodes;
+  private int size = 0;
+  // TODO make use when adding elements
+//  private static final int MAX_ARRAY_SIZE = 2147483639;
+  private static final int DEFAULT_CAPACITY = 10000;
+
+  //index into `nodes` array by node id
+  private final TLongIntMap nodeIndexByNodeId;
+  private final THashMap<String, Set<NodeRef>> nodesByLabel;
+
+  /** list of available slots in `nodes` array. slots become available after nodes have been removed */
+//  private final int[] emptySlots;
+
+  public NodesList() {
+    this(DEFAULT_CAPACITY);
+  }
+
+  public NodesList(int initialCapacity) {
+    nodes = new NodeRef[initialCapacity];
+    nodeIndexByNodeId = new TLongIntHashMap(10000);
+    nodesByLabel = new THashMap<>(10);
+  }
+
+  /** store NodeRef in internal collections */
+  public synchronized void add(NodeRef node) {
+    int index = size++;
+    nodes[index] = node;
+    nodeIndexByNodeId.put(node.id, index);
+    nodesByLabel(node.label()).add(node);
+  }
+
+  public NodeRef nodeById(long id) {
+    if (nodeIndexByNodeId.containsKey(id)) {
+      return nodes[nodeIndexByNodeId.get(id)];
+    } else {
+      return null;
+    }
+  }
+
+  public Set<NodeRef> nodesByLabel(String label) {
+    if (!nodesByLabel.containsKey(label))
+      nodesByLabel.put(label, new THashSet<>(10));
+
+    return nodesByLabel.get(label);
+  }
+
+  protected void removeNode(OdbNode node) {
+//    int index = nodeIndexByNodeId.remove(node.id2());
+//    nodes.remove(index);
+//
+//    indexManager.removeElement(node.ref);
+//    nodesByLabel.get(node.label()).remove(node.ref);
+//    storage.removeNode(node.id2());
+  }
+
+  public int size() {
+    return size;
+  }
+}

--- a/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
+++ b/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
@@ -9,7 +9,9 @@ import overflowdb.Node;
 
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -69,6 +71,10 @@ public class NodesList {
     return nextEmptySlot;
   }
 
+  public boolean contains(long id) {
+    return nodeIndexByNodeId.containsKey(id);
+  }
+
   public Node nodeById(long id) {
     if (nodeIndexByNodeId.containsKey(id)) {
       return nodes[nodeIndexByNodeId.get(id)];
@@ -77,7 +83,7 @@ public class NodesList {
     }
   }
 
-  protected void remove(Node node) {
+  public void remove(Node node) {
     int index = nodeIndexByNodeId.remove(node.id2());
     nodes[index] = null;
     emptySlots.set(index);
@@ -95,6 +101,16 @@ public class NodesList {
       nodesByLabel.put(label, new THashSet<>(10));
 
     return nodesByLabel.get(label);
+  }
+
+  public Set<String> nodeLabels() {
+    Set<String> ret = new HashSet<>(nodesByLabel.size());
+    nodesByLabel.entrySet().forEach(entry -> {
+      if (!entry.getValue().isEmpty()) {
+        ret.add(entry.getKey());
+      }
+    });
+    return ret;
   }
 
   public Iterator<Node> iterator() {
@@ -181,5 +197,4 @@ public class NodesList {
   protected int _elementDataSize() {
     return nodes.length;
   }
-
 }

--- a/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
+++ b/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
@@ -7,6 +7,7 @@ import gnu.trove.set.hash.THashSet;
 import overflowdb.NodeRef;
 import overflowdb.OdbNode;
 
+import java.util.Iterator;
 import java.util.Set;
 
 // TODO: this collection is only growing - intermittently trim it, e.g. if many elements have been deleted, after a GC run - note: must reeindex nodeIndexByNodeId
@@ -33,6 +34,23 @@ public class NodesList {
     nodeIndexByNodeId = new TLongIntHashMap(10000);
     nodesByLabel = new THashMap<>(10);
   }
+
+  public Iterator<NodeRef> iterator() {
+    return new Iterator<NodeRef>() {
+      // TODO copy array to avoid concurrent modification?
+      private int currIdx = 0;
+      @Override
+      public boolean hasNext() {
+        return currIdx < size;
+      }
+
+      @Override
+      public NodeRef next() {
+        return nodes[currIdx++];
+      }
+    };
+  }
+
 
   /** store NodeRef in internal collections */
   public synchronized void add(NodeRef node) {

--- a/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
@@ -107,6 +107,14 @@ public class NodesListTest {
     assertEquals(ref3, nl.nodeById(3L));
   }
 
+  @Test(expected = AssertionError.class)
+  public void idsAreUnique() {
+    NodesList nl = new NodesList();
+    nl.add(createDummyRef(1L, "A"));
+    nl.add(createDummyRef(1L, "B"));
+  }
+
+
 
 
   private NodeRef createDummyRef(long id, String label) {

--- a/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
@@ -85,6 +85,28 @@ public class NodesListTest {
     assertNull(nl.nodeById(1L));
   }
 
+  @Test
+  public void removeNodeThenAddMoreNodes() {
+    NodesList nl = new NodesList();
+
+    NodeRef ref1 = createDummyRef(1L, "A");
+    NodeRef ref2 = createDummyRef(2L, "B");
+    nl.add(ref1);
+    nl.add(ref2);
+
+    nl.remove(ref1);
+    NodeRef ref3 = createDummyRef(3L, "A");
+    nl.add(ref3);
+
+    assertEquals(2, nl.size());
+    assertEquals(1, nl.nodesByLabel("A").size());
+    assertTrue(nl.nodesByLabel("A").contains(ref3));
+    assertTrue(nl.nodesByLabel("B").contains(ref2));
+    assertNull(nl.nodeById(1L));
+    assertEquals(ref2, nl.nodeById(2L));
+    assertEquals(ref3, nl.nodeById(3L));
+  }
+
 
 
   private NodeRef createDummyRef(long id, String label) {

--- a/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
@@ -8,7 +8,7 @@ import overflowdb.OdbGraph;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class NodesListTest {
@@ -17,9 +17,9 @@ public class NodesListTest {
   public void addElements() {
     NodesList nl = new NodesList();
 
-    NodeRef ref1 = dummyRef(1L, "A");
-    NodeRef ref2 = dummyRef(2L, "A");
-    NodeRef ref3 = dummyRef(3L, "B");
+    NodeRef ref1 = createDummyRef(1L, "A");
+    NodeRef ref2 = createDummyRef(2L, "A");
+    NodeRef ref3 = createDummyRef(3L, "B");
     nl.add(ref1);
     nl.add(ref2);
     nl.add(ref3);
@@ -39,9 +39,9 @@ public class NodesListTest {
   public void growsAboveInitialCapacity() {
     NodesList nl = new NodesList(2);
 
-    NodeRef ref1 = dummyRef(1L, "A");
-    NodeRef ref2 = dummyRef(2L, "A");
-    NodeRef ref3 = dummyRef(3L, "B");
+    NodeRef ref1 = createDummyRef(1L, "A");
+    NodeRef ref2 = createDummyRef(2L, "A");
+    NodeRef ref3 = createDummyRef(3L, "B");
     nl.add(ref1);
     nl.add(ref2);
     nl.add(ref3);
@@ -62,15 +62,32 @@ public class NodesListTest {
     NodesList nl = new NodesList(2);
 
     for (int i = 0; i< 50000; i++) {
-      nl.add(dummyRef(i, "A" + i));
+      nl.add(createDummyRef(i, "A" + i));
     }
 
     assertEquals(50000, nl.size());
   }
 
-  // TODO test: remove nodes, reuse space
+  @Test
+  public void removeNode() {
+    NodesList nl = new NodesList();
 
-  private NodeRef dummyRef(long id, String label) {
+    NodeRef ref1 = createDummyRef(1L, "A");
+    NodeRef ref2 = createDummyRef(2L, "A");
+    nl.add(ref1);
+    nl.add(ref2);
+
+    nl.remove(ref1);
+    assertEquals(1, nl.size());
+    assertEquals(1, nl.nodesByLabel("A").size());
+    assertTrue(nl.nodesByLabel("A").contains(ref2));
+    assertEquals(ref2, nl.nodeById(2L));
+    assertNull(nl.nodeById(1L));
+  }
+
+
+
+  private NodeRef createDummyRef(long id, String label) {
     return new NodeRef(dummyGraph, id) {
       public String label() {
         return label;

--- a/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
@@ -155,6 +155,32 @@ public class NodesListTest {
     assertEquals(ref2, nl.nodeById(ref2.id));
   }
 
+  @Test
+  public void compactsAutomatically() {
+    NodesList nl = new NodesList();
+
+    final int nodeCount = 200_000;
+    Vector<NodeRef> bulkRefs = new Vector<>(nodeCount);
+    for (int i = 0; i < nodeCount; i++) {
+      NodeRef dummyRef = createDummyRef(i, "A");
+      nl.add(dummyRef);
+      bulkRefs.add(dummyRef);
+    }
+    assertEquals(nodeCount, nl.size());
+    assertTrue(
+        "internal element array should be large enough to hold all nodes (>= 200k), but has size " + nl._elementDataSize(),
+        nl._elementDataSize() >= nodeCount);
+
+    // delete all the bulk dummy nodes - this should (intermittently) automatically call 'collect'
+    bulkRefs.forEach(it -> nl.remove(it));
+    assertTrue(
+        "internal element array should have been compacted (< 50k), but has size " + nl._elementDataSize(),
+        nl._elementDataSize() < 50000);
+
+    System.out.println(nl._elementDataSize());
+    assertEquals(0, nl.size());
+  }
+
 
 
   private NodeRef createDummyRef(long id, String label) {

--- a/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
@@ -57,7 +57,17 @@ public class NodesListTest {
     assertTrue(nl.nodesByLabel("B").contains(ref3));
   }
 
-  // TODO test: grow above initial capacity
+  @Test
+  public void growsAboveInitialCapacity2() {
+    NodesList nl = new NodesList(2);
+
+    for (int i = 0; i< 50000; i++) {
+      nl.add(dummyRef(i, "A" + i));
+    }
+
+    assertEquals(50000, nl.size());
+  }
+
   // TODO test: remove nodes, reuse space
 
   private NodeRef dummyRef(long id, String label) {

--- a/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/util/NodesListTest.java
@@ -1,0 +1,72 @@
+package overflowdb.util;
+
+import org.junit.Test;
+import overflowdb.NodeRef;
+import overflowdb.OdbConfig;
+import overflowdb.OdbGraph;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NodesListTest {
+
+  @Test
+  public void addElements() {
+    NodesList nl = new NodesList();
+
+    NodeRef ref1 = dummyRef(1L, "A");
+    NodeRef ref2 = dummyRef(2L, "A");
+    NodeRef ref3 = dummyRef(3L, "B");
+    nl.add(ref1);
+    nl.add(ref2);
+    nl.add(ref3);
+
+    assertEquals(3, nl.size());
+    assertEquals(2, nl.nodesByLabel("A").size());
+    assertEquals(1, nl.nodesByLabel("B").size());
+    assertEquals(ref1, nl.nodeById(1L));
+    assertEquals(ref2, nl.nodeById(2L));
+    assertEquals(ref3, nl.nodeById(3L));
+    assertTrue(nl.nodesByLabel("A").contains(ref1));
+    assertTrue(nl.nodesByLabel("A").contains(ref2));
+    assertTrue(nl.nodesByLabel("B").contains(ref3));
+  }
+
+  @Test
+  public void growsAboveInitialCapacity() {
+    NodesList nl = new NodesList(2);
+
+    NodeRef ref1 = dummyRef(1L, "A");
+    NodeRef ref2 = dummyRef(2L, "A");
+    NodeRef ref3 = dummyRef(3L, "B");
+    nl.add(ref1);
+    nl.add(ref2);
+    nl.add(ref3);
+
+    assertEquals(3, nl.size());
+    assertEquals(2, nl.nodesByLabel("A").size());
+    assertEquals(1, nl.nodesByLabel("B").size());
+    assertEquals(ref1, nl.nodeById(1L));
+    assertEquals(ref2, nl.nodeById(2L));
+    assertEquals(ref3, nl.nodeById(3L));
+    assertTrue(nl.nodesByLabel("A").contains(ref1));
+    assertTrue(nl.nodesByLabel("A").contains(ref2));
+    assertTrue(nl.nodesByLabel("B").contains(ref3));
+  }
+
+  // TODO test: grow above initial capacity
+  // TODO test: remove nodes, reuse space
+
+  private NodeRef dummyRef(long id, String label) {
+    return new NodeRef(dummyGraph, id) {
+      public String label() {
+        return label;
+      }
+    };
+  }
+
+  private OdbGraph dummyGraph = OdbGraph.open(OdbConfig.withoutOverflow(), new ArrayList<>(), new ArrayList<>());
+}

--- a/traversal/src/main/scala/overflowdb/traversal/TraversalSource.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/TraversalSource.scala
@@ -4,7 +4,8 @@ import overflowdb.{Node, OdbGraph}
 
 class TraversalSource(graph: OdbGraph) {
   def all: Traversal[Node] =
-    Traversal(graph.nodes())
+    ???
+//    Traversal(graph.nodes())
 
   def id(id: Long): Traversal[Node] =
     Traversal(graph.node(id))

--- a/traversal/src/main/scala/overflowdb/traversal/TraversalSource.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/TraversalSource.scala
@@ -4,8 +4,7 @@ import overflowdb.{Node, OdbGraph}
 
 class TraversalSource(graph: OdbGraph) {
   def all: Traversal[Node] =
-    ???
-//    Traversal(graph.nodes())
+    Traversal(graph.nodes())
 
   def id(id: Long): Traversal[Node] =
     Traversal(graph.node(id))


### PR DESCRIPTION
* motivation: graph.nodes is extremely slow. while it's recommended to not traverse _all_ nodes normally, sometimes it's necessary
* IteratorUtils has an unnecessary performance hit
* iterating all nodes is 5-10x faster (only performed very simplistic benchmarks)
* less memory usage when only adding nodes
* automatically compacts so that far less memory is used when nodes are being removed