### PR TITLE
make node removal persistent

### DIFF
--- a/tinkerpop3/src/main/java/overflowdb/NodeRef.java
+++ b/tinkerpop3/src/main/java/overflowdb/NodeRef.java
@@ -141,7 +141,8 @@ public abstract class NodeRef<N extends OdbNode> implements Vertex, Node {
 
   @Override
   public void remove() {
-    this.get().remove();
+    get().remove();
+    clear();
   }
 
   @Override

--- a/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
@@ -415,6 +415,7 @@ public final class OdbGraph implements Graph {
 
   public void remove(Node node) {
     nodes.remove(node);
+    storage.removeNode(node.id2());
   }
 
   public class GraphFeatures implements Features {

--- a/tinkerpop3/src/test/java/overflowdb/IndexesTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/IndexesTest.java
@@ -26,7 +26,7 @@ public class IndexesTest {
     final double avgTimeWithoutIndex;
 
     { // tests with index
-      OdbGraph graph = GratefulDead.newGraphWithData();
+      OdbGraph graph = GratefulDead.openAndLoadSampleData();
       graph.indexManager.createNodePropertyIndex("performances");
       GraphTraversalSource g = graph.traversal();
       assertEquals(142, (long) g.V().has("performances", P.eq(1)).count().next());
@@ -35,7 +35,7 @@ public class IndexesTest {
     }
 
     { // tests without index
-      OdbGraph graph = GratefulDead.newGraphWithData();
+      OdbGraph graph = GratefulDead.openAndLoadSampleData();
       GraphTraversalSource g = graph.traversal();
       assertEquals(142, (long) g.V().has("performances", P.eq(1)).count().next());
       avgTimeWithoutIndex = TimeUtil.clock(loops, () -> g.V().has("performances", P.eq(1)).count().next());
@@ -56,7 +56,7 @@ public class IndexesTest {
     final double avgTimeWithoutIndex;
 
     { // tests with index
-      OdbGraph graph = GratefulDead.newGraph();
+      OdbGraph graph = GratefulDead.open();
       graph.indexManager.createNodePropertyIndex("performances");
       GratefulDead.loadData(graph);
       GraphTraversalSource g = graph.traversal();
@@ -66,7 +66,7 @@ public class IndexesTest {
     }
 
     { // tests without index
-      OdbGraph graph = GratefulDead.newGraphWithData();
+      OdbGraph graph = GratefulDead.openAndLoadSampleData();
       GraphTraversalSource g = graph.traversal();
       assertEquals(142, (long) g.V().has("performances", P.eq(1)).count().next());
       avgTimeWithoutIndex = TimeUtil.clock(loops, () -> g.V().has("performances", P.eq(1)).count().next());
@@ -89,7 +89,7 @@ public class IndexesTest {
     // tests with index
     int loops = 1000;
     avgTimeWithIndexCreation = TimeUtil.clock(loops, () -> {
-      try(OdbGraph graph = GratefulDead.newGraphWithData()) {
+      try(OdbGraph graph = GratefulDead.openAndLoadSampleData()) {
         graph.indexManager.createNodePropertyIndex("performances");
         GraphTraversalSource g = graph.traversal();
         assertEquals(142, (long) g.V().has("performances", P.eq(1)).count().next());
@@ -98,14 +98,14 @@ public class IndexesTest {
       }
     });
     // save indexes
-    try(OdbGraph graph = GratefulDead.newGraphWithData(overflowDb.getAbsolutePath())) {
+    try(OdbGraph graph = GratefulDead.openAndLoadSampleData(overflowDb.getAbsolutePath())) {
       graph.indexManager.createNodePropertyIndex("performances");
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
     // tests with stored index
     avgTimeWithStoredIndex = TimeUtil.clock(loops, () -> {
-      try(OdbGraph graph = GratefulDead.newGraph(OdbConfig.withDefaults().withStorageLocation(overflowDb.getAbsolutePath()))) {
+      try(OdbGraph graph = GratefulDead.open(OdbConfig.withDefaults().withStorageLocation(overflowDb.getAbsolutePath()))) {
         GraphTraversalSource g = graph.traversal();
         assertEquals(142, (long) g.V().has("performances", P.eq(1)).count().next());
       }
@@ -120,13 +120,13 @@ public class IndexesTest {
     final File overflowDb = Files.createTempFile("overflowdb", "bin").toFile();
     overflowDb.deleteOnExit();
     // save indexes
-    try(OdbGraph graph = GratefulDead.newGraphWithData(overflowDb.getAbsolutePath())) {
+    try(OdbGraph graph = GratefulDead.openAndLoadSampleData(overflowDb.getAbsolutePath())) {
       graph.indexManager.createNodePropertyIndex("performances");
       assertEquals(584, graph.indexManager.getIndexedNodeCount("performances"));
       assertEquals(new HashSet<String>(Arrays.asList("performances")), graph.indexManager.getIndexedNodeProperties());
     }
     // tests with stored index
-    try(OdbGraph graph = GratefulDead.newGraph(OdbConfig.withDefaults().withStorageLocation(overflowDb.getAbsolutePath()))) {
+    try(OdbGraph graph = GratefulDead.open(OdbConfig.withDefaults().withStorageLocation(overflowDb.getAbsolutePath()))) {
       assertEquals(584, graph.indexManager.getIndexedNodeCount("performances"));
       assertEquals(new HashSet<String>(Arrays.asList("performances")), graph.indexManager.getIndexedNodeProperties());
     }

--- a/tinkerpop3/src/test/java/overflowdb/OdbNodeTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/OdbNodeTest.java
@@ -94,7 +94,7 @@ public class OdbNodeTest {
 
   @Test
   public void loadGratefulDeadGraph() throws IOException {
-    try(OdbGraph graph = GratefulDead.newGraphWithData()) {
+    try(OdbGraph graph = GratefulDead.openAndLoadSampleData()) {
       final Node node1 = graph.node(1);
       assertEquals("HEY BO DIDDLEY", node1.property2("name"));
 
@@ -323,7 +323,7 @@ public class OdbNodeTest {
 
   @Test
   public void shouldAllowAddingElementsAndSettingProperties() {
-    try(OdbGraph graph = GratefulDead.newGraph()) {
+    try(OdbGraph graph = GratefulDead.open()) {
 
       Node song1 = graph.addNode(Song.label);
       Node song2 = graph.addNode(Song.label);
@@ -345,7 +345,7 @@ public class OdbNodeTest {
 
   @Test
   public void shouldSupportEdgeRemoval1() {
-    try (OdbGraph graph = GratefulDead.newGraph()) {
+    try (OdbGraph graph = GratefulDead.open()) {
       Node song1 = graph.addNode(Song.label);
       Node song2 = graph.addNode(Song.label);
       OdbEdge followedBy = song1.addEdge2(FollowedBy.LABEL, song2);
@@ -360,7 +360,7 @@ public class OdbNodeTest {
 
   @Test
   public void shouldSupportEdgeRemoval2() {
-    try (OdbGraph graph = GratefulDead.newGraph()) {
+    try (OdbGraph graph = GratefulDead.open()) {
       Node song1 = graph.addNode(Song.label);
       Node song2 = graph.addNode(Song.label);
       Node song3 = graph.addNode(Song.label);
@@ -381,7 +381,7 @@ public class OdbNodeTest {
 
   @Test
   public void nodeRemove1() {
-    try (OdbGraph graph = GratefulDead.newGraph()) {
+    try (OdbGraph graph = GratefulDead.open()) {
       Node song1 = graph.addNode(Song.label);
       Node song2 = graph.addNode(Song.label);
       song1.addEdge2(FollowedBy.LABEL, song2);
@@ -399,7 +399,7 @@ public class OdbNodeTest {
 
   @Test
   public void nodeRemove2() {
-    try (OdbGraph graph = GratefulDead.newGraph()) {
+    try (OdbGraph graph = GratefulDead.open()) {
       Node song1 = graph.addNode(Song.label);
       Node song2 = graph.addNode(Song.label);
       song1.addEdge2(FollowedBy.LABEL, song2);
@@ -417,7 +417,7 @@ public class OdbNodeTest {
 
   @Test
   public void nodeRemove3() {
-    try (OdbGraph graph = GratefulDead.newGraph()) {
+    try (OdbGraph graph = GratefulDead.open()) {
       Node song1 = graph.addNode(Song.label);
       Node song2 = graph.addNode(Song.label);
       Node song3 = graph.addNode(Song.label);
@@ -435,7 +435,7 @@ public class OdbNodeTest {
 
   @Test
   public void nodeRemove4() {
-    try (OdbGraph graph = GratefulDead.newGraph()) {
+    try (OdbGraph graph = GratefulDead.open()) {
       Node song1 = graph.addNode(Song.label);
       Node song2 = graph.addNode(Song.label);
       Node song3 = graph.addNode(Song.label);
@@ -453,7 +453,7 @@ public class OdbNodeTest {
 
   @Test
   public void nodeRemove5_twoEdgesBetweenTwoNodes() {
-    try (OdbGraph graph = GratefulDead.newGraph()) {
+    try (OdbGraph graph = GratefulDead.open()) {
       Node song1 = graph.addNode(Song.label);
       Node song2 = graph.addNode(Song.label);
       song1.addEdge2(FollowedBy.LABEL, song2);
@@ -469,7 +469,7 @@ public class OdbNodeTest {
 
   @Test
   public void nodeRemove6() {
-    try (OdbGraph graph = GratefulDead.newGraph()) {
+    try (OdbGraph graph = GratefulDead.open()) {
       Node song1 = graph.addNode(Song.label);
       Node song2 = graph.addNode(Song.label);
       Node song3 = graph.addNode(Song.label);
@@ -492,7 +492,7 @@ public class OdbNodeTest {
 
   @Test
   public void shouldAllowToSpecifyIds() {
-    try(OdbGraph graph = GratefulDead.newGraph()) {
+    try(OdbGraph graph = GratefulDead.open()) {
       Node n10 = graph.addNode(10l, Song.label, Song.NAME, "Song 10");
       Node n20 = graph.addNode(20l, Song.label, Song.NAME, "Song 20");
       n10.addEdge2(FollowedBy.LABEL, n20, FollowedBy.WEIGHT, 5);
@@ -504,7 +504,7 @@ public class OdbNodeTest {
 
   @Test
   public void shouldReturnElementRefs() {
-    try (OdbGraph graph = GratefulDead.newGraph()) {
+    try (OdbGraph graph = GratefulDead.open()) {
       Node n0 = graph.addNode(Song.label, Song.NAME, "Song 1");
       Node n2 = graph.addNode(Song.label, Song.NAME, "Song 2");
       OdbEdge e4 = n0.addEdge2(FollowedBy.LABEL, n2);

--- a/tinkerpop3/src/test/java/overflowdb/TinkerpopTraversalTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/TinkerpopTraversalTest.java
@@ -56,7 +56,7 @@ public class TinkerpopTraversalTest {
 
   @Test
   public void basicOutInSteps() {
-    OdbGraph graph = GratefulDead.newGraph();
+    OdbGraph graph = GratefulDead.open();
 
     Vertex v0 = graph.addVertex(T.label, Song.label, Song.NAME, "Song 1");
     Vertex v2 = graph.addVertex(T.label, Song.label, Song.NAME, "Song 2");
@@ -79,7 +79,7 @@ public class TinkerpopTraversalTest {
 
   @Test
   public void testBasicSteps() throws IOException {
-    try (OdbGraph graph = GratefulDead.newGraphWithData()) {
+    try (OdbGraph graph = GratefulDead.openAndLoadSampleData()) {
       Vertex garcia = graph.traversal().V().has("name", "Garcia").next();
 
       // inE
@@ -114,7 +114,7 @@ public class TinkerpopTraversalTest {
 
   @Test
   public void handleEmptyProperties() throws IOException {
-    try (OdbGraph graph = GratefulDead.newGraphWithData()) {
+    try (OdbGraph graph = GratefulDead.openAndLoadSampleData()) {
       List<Object> props1 = graph.traversal().V().values("foo").toList();
       // results will be empty, but it should't crash. see https://github.com/ShiftLeftSecurity/tinkergraph-gremlin/issues/12
       assertEquals(props1.size(), 0);

--- a/tinkerpop3/src/test/java/overflowdb/TraversalOptimizationTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/TraversalOptimizationTest.java
@@ -16,7 +16,7 @@ public class TraversalOptimizationTest {
 
   @Test
   public void optimizationStrategyAffectedSteps() throws IOException {
-    try (OdbGraph graph = GratefulDead.newGraphWithData()) {
+    try (OdbGraph graph = GratefulDead.openAndLoadSampleData()) {
       // using `g.V().hasLabel(lbl)` optimization
       assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
       assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());

--- a/tinkerpop3/src/test/java/overflowdb/storage/GraphSaveRestoreTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/storage/GraphSaveRestoreTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * save and restore a graph from disk overlay
@@ -31,7 +32,7 @@ public class GraphSaveRestoreTest {
     final Long node0Id;
     final Long node1Id;
     // create graph and store in specified location
-    try (OdbGraph graph = newGratefulDeadGraph(storageFile, false)) {
+    try (OdbGraph graph = openGratefulDeadGraph(storageFile, false)) {
       Node n0 = graph.addNode(Song.label, Song.NAME, "Song 1");
       Node n1 = graph.addNode(Song.label, Song.NAME, "Song 2");
       OdbEdge edge = n0.addEdge2(FollowedBy.LABEL, n1, FollowedBy.WEIGHT, 42);
@@ -40,7 +41,7 @@ public class GraphSaveRestoreTest {
     } // ARM auto-close will trigger saving to disk because we specified a location
 
     // reload from disk
-    try (OdbGraph graph = newGratefulDeadGraph(storageFile, false)) {
+    try (OdbGraph graph = openGratefulDeadGraph(storageFile, false)) {
       assertEquals(2, graph.nodeCount());
       assertEquals(Long.valueOf(1), graph.traversal().V().outE().count().next());
       assertEquals("Song 1", graph.node(node0Id).property2(Song.NAME));
@@ -60,12 +61,12 @@ public class GraphSaveRestoreTest {
     final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
     storageFile.deleteOnExit();
 
-    try (OdbGraph graph = newGratefulDeadGraph(storageFile, false)) {
+    try (OdbGraph graph = openGratefulDeadGraph(storageFile, false)) {
       loadGraphMl(graph);
     } // ARM auto-close will trigger saving to disk because we specified a location
 
     // reload from disk
-    try (OdbGraph graph = newGratefulDeadGraph(storageFile, false)) {
+    try (OdbGraph graph = openGratefulDeadGraph(storageFile, false)) {
       assertEquals(808, graph.nodeCount());
       assertEquals(Long.valueOf(8049), graph.traversal().V().outE().count().next());
     }
@@ -76,12 +77,12 @@ public class GraphSaveRestoreTest {
     final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
     storageFile.deleteOnExit();
 
-    try (OdbGraph graph = newGratefulDeadGraph(storageFile, true)) {
+    try (OdbGraph graph = openGratefulDeadGraph(storageFile, true)) {
       loadGraphMl(graph);
     } // ARM auto-close will trigger saving to disk because we specified a location
 
     // reload from disk
-    try (OdbGraph graph = newGratefulDeadGraph(storageFile, true)) {
+    try (OdbGraph graph = openGratefulDeadGraph(storageFile, true)) {
       assertEquals(808, graph.nodeCount());
       assertEquals(Long.valueOf(8049), graph.traversal().V().outE().count().next());
     }
@@ -160,19 +161,23 @@ public class GraphSaveRestoreTest {
       // remove node
       Node newSong = (Node) graph.traversal().V().has(Song.NAME, "new song").next();
       newSong.remove();
-      int expectedSerializationCount = 1;
+      int expectedSerializationCount = 0;
       return expectedSerializationCount;
     });
+
+    // verify that deleted node is actually gone
+    OdbGraph graph = openGratefulDeadGraph(storageFile, false);
+    assertFalse("node should have been deleted from storage", graph.traversal().V().has(Song.NAME, "new song").hasNext());
   }
 
   private void modifyAndCloseGraph(File storageFile, Function<OdbGraph, Integer> graphModifications) {
-    OdbGraph graph = newGratefulDeadGraph(storageFile, false);
+    OdbGraph graph = openGratefulDeadGraph(storageFile, false);
     int expectedSerializationCount = graphModifications.apply(graph);
     graph.close();
     assertEquals(expectedSerializationCount, graph.getStorage().nodeSerializer.getSerializedCount());
   }
 
-  private OdbGraph newGratefulDeadGraph(File overflowDb, boolean enableOverflow) {
+  private OdbGraph openGratefulDeadGraph(File overflowDb, boolean enableOverflow) {
     OdbConfig config = enableOverflow ? OdbConfig.withDefaults() : OdbConfig.withoutOverflow();
     config = config.withSerializationStatsEnabled();
     return GratefulDead.open(config.withStorageLocation(overflowDb.getAbsolutePath()));

--- a/tinkerpop3/src/test/java/overflowdb/storage/GraphSaveRestoreTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/storage/GraphSaveRestoreTest.java
@@ -175,7 +175,7 @@ public class GraphSaveRestoreTest {
   private OdbGraph newGratefulDeadGraph(File overflowDb, boolean enableOverflow) {
     OdbConfig config = enableOverflow ? OdbConfig.withDefaults() : OdbConfig.withoutOverflow();
     config = config.withSerializationStatsEnabled();
-    return GratefulDead.newGraph(config.withStorageLocation(overflowDb.getAbsolutePath()));
+    return GratefulDead.open(config.withStorageLocation(overflowDb.getAbsolutePath()));
   }
 
   private void loadGraphMl(OdbGraph graph) throws RuntimeException {

--- a/tinkerpop3/src/test/java/overflowdb/testdomains/gratefuldead/GratefulDead.java
+++ b/tinkerpop3/src/test/java/overflowdb/testdomains/gratefuldead/GratefulDead.java
@@ -8,11 +8,11 @@ import java.io.IOException;
 import java.util.Arrays;
 
 public class GratefulDead {
-  public static OdbGraph newGraph() {
-    return newGraph(OdbConfig.withoutOverflow());
+  public static OdbGraph open() {
+    return open(OdbConfig.withoutOverflow());
   }
 
-  public static OdbGraph newGraph(OdbConfig config) {
+  public static OdbGraph open(OdbConfig config) {
     return OdbGraph.open(
         config,
         Arrays.asList(Song.factory, Artist.factory),
@@ -20,14 +20,14 @@ public class GratefulDead {
     );
   }
 
-  public static OdbGraph newGraphWithData() throws IOException {
-    OdbGraph graph = newGraph();
+  public static OdbGraph openAndLoadSampleData() throws IOException {
+    OdbGraph graph = open();
     loadData(graph);
     return graph;
   }
 
-  public static OdbGraph newGraphWithData(String path) throws IOException {
-    OdbGraph graph = newGraph(OdbConfig.withDefaults().withStorageLocation(path));
+  public static OdbGraph openAndLoadSampleData(String path) throws IOException {
+    OdbGraph graph = open(OdbConfig.withDefaults().withStorageLocation(path));
     loadData(graph);
     return graph;
   }


### PR DESCRIPTION
Prior to this, removing a node would apply to the current in-memory
graph, but it would reappear after closing and reopening the graph.
Two changes were needed to fix that:
1) explicitly remove it from the storage mvstore map
2) clear the `NodeRef.node` instance (of type `OdbNode`), so that the
reference manager cannot persist it. This is not the most obvious way
to achieve that, but the one with the smallest impact, since we don't
need to add another field like 'removed' to NodeRef, and can keep the
ReferenceManager's collection type as is.