### PR TITLE
repeat step: take Traversal[A] => Traversal[B]

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/RepeatStep.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/RepeatStep.scala
@@ -1,6 +1,7 @@
 package overflowdb.traversal
 
-import RepeatBehaviour.SearchAlgorithm
+import overflowdb.traversal.RepeatBehaviour.SearchAlgorithm
+
 import scala.collection.{Iterator, mutable}
 
 object RepeatStep {
@@ -11,7 +12,7 @@ object RepeatStep {
    * for ~10k steps. So instead, this uses a programmatic Stack which is semantically identical.
    * The RepeatTraversalTests cover this case.
    * */
-  def apply[A](repeatTraversal: A => Traversal[A], behaviour: RepeatBehaviour[A]): A => Traversal[A] = {
+  def apply[A](repeatTraversal: Traversal[A] => Traversal[A], behaviour: RepeatBehaviour[A]): A => Traversal[A] = {
     val worklist: Worklist[A] = behaviour.searchAlgorithm match {
       case SearchAlgorithm.DepthFirst   => new LifoWorklist[A]
       case SearchAlgorithm.BreadthFirst => new FifoWorklist[A]
@@ -43,7 +44,7 @@ object RepeatStep {
               emitSack.enqueue(element)
               stop = true
             } else {
-              worklist.addItem(WorklistItem(repeatTraversal(element), depth + 1))
+              worklist.addItem(WorklistItem(repeatTraversal(Traversal.fromSingle(element)), depth + 1))
               if (behaviour.shouldEmit(element, depth)) emitSack.enqueue(element)
               if (emitSack.nonEmpty) stop = true
             }

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -157,11 +157,11 @@ class Traversal[A](elements: IterableOnce[A])
    *
    * @see RepeatTraversalTests for more detail and examples for all of the above.
    */
-  final def repeat[B >: A](repeatTraversal: A => Traversal[B])
+  final def repeat[B >: A](repeatTraversal: Traversal[A] => Traversal[B])
     (implicit behaviourBuilder: RepeatBehaviour.Builder[B] => RepeatBehaviour.Builder[B] = RepeatBehaviour.noop[B] _)
     : Traversal[B] = {
     val behaviour = behaviourBuilder(new RepeatBehaviour.Builder[B]).build
-    val _repeatTraversal = repeatTraversal.asInstanceOf[B => Traversal[B]] //this cast usually :tm: safe, because `B` is a supertype of `A`
+    val _repeatTraversal = repeatTraversal.asInstanceOf[Traversal[B] => Traversal[B]] //this cast usually :tm: safe, because `B` is a supertype of `A`
     flatMap(RepeatStep(_repeatTraversal, behaviour))
   }
 


### PR DESCRIPTION
for consistency with other steps, and to preserve tinkerpop semantics