### PR TITLE
TraversalSource: start with label and property, choose best case

### DIFF
--- a/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
+++ b/tinkerpop3/src/main/java/overflowdb/OdbGraph.java
@@ -279,6 +279,10 @@ public final class OdbGraph implements Graph {
     return nodes.size();
   }
 
+  public int nodeCount(String label) {
+    return nodes.cardinality(label);
+  }
+
   public int edgeCount() {
     int i = 0;
     final Iterator<OdbEdge> edges = edges();

--- a/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
+++ b/tinkerpop3/src/main/java/overflowdb/util/NodesList.java
@@ -15,7 +15,6 @@ import java.util.BitSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Set;
 
 public class NodesList {
@@ -197,6 +196,14 @@ public class NodesList {
   /** just for unit test */
   protected int _elementDataSize() {
     return nodes.length;
+  }
+
+  /** cardinality of nodes for given label */
+  public int cardinality(String label) {
+    if (nodesByLabel.containsKey(label))
+      return nodesByLabel.get(label).size();
+    else
+      return 0;
   }
 
   public static class NodesIterator implements Iterator<Node> {

--- a/traversal/src/test/scala/overflowdb/traversal/TraversalSourceTest.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/TraversalSourceTest.scala
@@ -17,6 +17,11 @@ class TraversalSourceTest extends WordSpec with Matchers {
     def verify() = {
       TraversalSource(graph).has(Name -> "one").toSet shouldBe Set(one)
       TraversalSource(graph).has(Name -> "two").toSet shouldBe Set(two1, two2)
+      TraversalSource(graph).has(Name -> "unknown").toSet shouldBe Set.empty
+
+      TraversalSource(graph).labelAndProperty(Thing.Label, Name -> "two").toSet shouldBe Set(two1, two2)
+      TraversalSource(graph).labelAndProperty(Thing.Label, Name -> "unknown").toSet shouldBe Set.empty
+      TraversalSource(graph).labelAndProperty("unknown", Name -> "two").toSet shouldBe Set.empty
     }
 
     verify()


### PR DESCRIPTION
* Inspects the cardinality of the indices of the properties and labels, and takes the smaller one