### PR TITLE
drop tricky varargs

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/filter/P.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/filter/P.scala
@@ -13,14 +13,8 @@ object P {
   def within[A](values: Set[A]): A => Boolean =
     values.contains
 
-  def within[A](values: A*): A => Boolean =
-    within(values.to(Set))
-
   def without[A](values: Set[A]): A => Boolean =
     a => !values.contains(a)
-
-  def without[A](values: A*): A => Boolean =
-    without(values.to(Set))
 
   def matches(regex: String): String => Boolean =
     matches(regex.r)

--- a/traversal/src/test/scala/overflowdb/traversal/GenericGraphTraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/GenericGraphTraversalTests.scala
@@ -70,9 +70,7 @@ class GenericGraphTraversalTests extends WordSpec with Matchers {
       graph.V.has(Name.where(_.matches("[LR]."))).size shouldBe 8
       graph.V.has(Name.where(P.neq("R1"))).size shouldBe 8
       graph.V.has(Name.where(P.within(Set("L1", "L2")))).size shouldBe 2
-      graph.V.has(Name.where(P.within("L1", "L2", "L3"))).size shouldBe 3
       graph.V.has(Name.where(P.without(Set("L1", "L2")))).size shouldBe 7
-      graph.V.has(Name.where(P.without("L1", "L2", "L3"))).size shouldBe 6
       graph.V.has(Name.where(_.endsWith("1"))).size shouldBe 2
       graph.E.has(Distance.of(10)).size shouldBe 2
 
@@ -83,9 +81,7 @@ class GenericGraphTraversalTests extends WordSpec with Matchers {
       graph.V.hasNot(Name.where(_.matches("[LR]."))).size shouldBe 1
       graph.V.hasNot(Name.where(P.neq("R1"))).size shouldBe 1
       graph.V.hasNot(Name.where(P.within(Set("L1", "L2")))).size shouldBe 7
-      graph.V.hasNot(Name.where(P.within("L1", "L2", "L3"))).size shouldBe 6
       graph.V.hasNot(Name.where(P.without(Set("L1", "L2")))).size shouldBe 2
-      graph.V.hasNot(Name.where(P.without("L1", "L2", "L3"))).size shouldBe 3
       graph.V.hasNot(Name.where(_.endsWith("1"))).size shouldBe 7
       graph.E.hasNot(Distance.of(10)).size shouldBe 6
     }


### PR DESCRIPTION
P.within/without with varargs is dangerous, because of the unspecific
type parameter A.

example for misuse:
`def a(allowed: String*) = P.within(allowed)`
creates `Seq[String] => Boolean` and not `String => Boolean` as the user
may intend