### PR TITLE
enable mvstore compression: 3x storage space for 5% performance

### DIFF
--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -139,6 +139,7 @@ public class OdbStorage implements AutoCloseable {
     final MVStore store = new MVStore.Builder()
         .fileName(mvstoreFile.getAbsolutePath())
         .autoCommitBufferSize(1024 * 8)
+        .compress()
         .open();
     return store;
   }


### PR DESCRIPTION
* rough comparison of the different options with cpg2sp time and sp.bin file size for openxava:

```
no compression (master): 298M, 122s
  + manual zip compression: 48M, +5s

mvstore compress: 99M, 126s
  + manual zip compression: 65M, +5s

mvstore compressHigh: 69M, 131s
  + manual zip compression: 67M, +5s
```