### PR TITLE
Downgrade org.reflections to 0.9.11 due to a bug

### DIFF
--- a/traversal/build.sbt
+++ b/traversal/build.sbt
@@ -2,7 +2,7 @@ name := "overflowdb-traversal"
 
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  "org.reflections" % "reflections" % "0.9.12",
+  "org.reflections" % "reflections" % "0.9.11", // 0.9.12 is broken
   "com.massisframework" % "j-text-utils" % "0.3.4",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "org.slf4j" % "slf4j-simple" % "1.7.28" % Test,


### PR DESCRIPTION
Apparently I'm able to invoke our codepropertygraph's console via a path
that triggers https://github.com/ronmamo/reflections/issues/273.
This is very unfortunate and due to the way the artifact is being
published I'm unable to downgrade directly in the project I use.
Sadly this dependency is propagated very far down the chain and it
impossible to untangle it.

The fix is in 0.9.13-SNAPSHOT (not yet released) so suggesting to
downgrade until it is officially out.