### PR TITLE
Replace reflections package with reflections8

### DIFF
--- a/traversal/build.sbt
+++ b/traversal/build.sbt
@@ -2,7 +2,7 @@ name := "overflowdb-traversal"
 
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  "org.reflections" % "reflections" % "0.9.12",
+  "net.oneandone.reflections8" % "reflections8" % "0.11.7", // go back to reflections once 0.9.13 is released
   "com.massisframework" % "j-text-utils" % "0.3.4",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "org.slf4j" % "slf4j-simple" % "1.7.28" % Test,

--- a/traversal/src/main/scala/overflowdb/traversal/help/TraversalHelp.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/help/TraversalHelp.scala
@@ -4,7 +4,7 @@ import overflowdb.traversal.{ElementTraversal, NodeTraversal, Traversal, help}
 import overflowdb.{NodeRef, NodeDb}
 import java.lang.annotation.{Annotation => JAnnotation}
 
-import org.reflections.Reflections
+import org.reflections8.Reflections
 
 import scala.annotation.tailrec
 import scala.reflect.runtime.universe.runtimeMirror


### PR DESCRIPTION
Apparently I'm able to invoke our codepropertygraph's console via a path
that triggers ronmamo/reflections#273.
This is very unfortunate and due to the way the artifact is being
published I'm unable to downgrade directly in the project I use.
Sadly this dependency is propagated very far down the chain and it
impossible to untangle it.

The fix is in `0.9.13-SNAPSHOT` (not yet released) so suggesting to
downgrade until it is officially out.

Note: I was going to just downgrade to `0.9.11` but looks like that
version is pretty ancient. Instead I followed the same suggestion as in
https://github.com/JanusGraph/janusgraph/pull/2029
and replaced `reflections` with `reflections8` until `0.9.13` is
released.