### PR TITLE
Ensure one space on the right of all table cells.

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/help/Table.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/help/Table.scala
@@ -12,7 +12,7 @@ case class Table(columnNames: Iterable[String], rows: Iterable[Iterable[String]]
       val charset = StandardCharsets.UTF_8
       val baos = use(new ByteArrayOutputStream)
       val ps = use(new PrintStream(baos, true, charset.name))
-      val rowsAsArray = rows.map(_.toArray.asInstanceOf[Array[Object]]).toArray
+      val rowsAsArray = rows.map(_.map(_ + " ").toArray.asInstanceOf[Array[Object]]).toArray
       new TextTable(columnNames.toArray, rowsAsArray).printTable(ps, 0)
       new String(baos.toByteArray, charset)
     }.get


### PR DESCRIPTION
Otherwise copy&pasting on terminals is annoying, to wit:

```
___________________________________________________________________________________________________________________________________
| name       | overlays                    | inputPath                                                                      | open |
|==================================================================================================================================|
| cpg.bin.zip| tagging,dataflow,semanticcpg| /home/....../src/go/src/github.com/....../........................./cpg.bin.zip| false|
```

Double-clicking on e.g. `cpg.bin.zip` will still highlight the whole `cpg.bin.zip|` part, same for everything else.

With this change it should (hopefully) be just `cpg.bin.zip` due to the additional space character on the right-hand side.