### PR TITLE
improve log output when closing the graph

### DIFF
--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -96,7 +96,7 @@ public class OdbStorage implements AutoCloseable {
   /** flush any remaining changes in underlying storage to disk */
   public void flush() {
     if (mvstore != null) {
-      logger.debug("flushing to disk");
+      logger.trace("flushing to disk");
       mvstore.commit();
     }
   }


### PR DESCRIPTION
example output:
```
2020-10-05 14:04:17.291 DEBUG uninstalled GC monitors.
2020-10-05 14:04:17.961 INFO progress of clearing references: 18.96%
2020-10-05 14:04:18.591 INFO progress of clearing references: 37.92%
2020-10-05 14:04:19.119 INFO progress of clearing references: 56.88%
2020-10-05 14:04:19.716 INFO progress of clearing references: 75.84%
2020-10-05 14:04:20.255 INFO progress of clearing references: 94.80%
2020-10-05 14:04:20.346 INFO progress of clearing references: 100.00%
2020-10-05 14:04:20.346 INFO cleared all clearable references
2020-10-05 14:04:20.346 DEBUG closing OdbStorage
```