### PR TITLE
Fix memory model violation / race condition: Dirty-flag must be volatile

### DIFF
--- a/core/src/main/java/overflowdb/NodeDb.java
+++ b/core/src/main/java/overflowdb/NodeDb.java
@@ -44,7 +44,7 @@ public abstract class NodeDb implements Node {
    * `true`  when node is first created, or is modified (property or edges)
    * `false` when node is freshly serialized to disk or deserialized from disk
    */
-  private boolean dirty;
+  private volatile boolean dirty;
 
   private static final String[] ALL_LABELS = new String[0];
 


### PR DESCRIPTION
If I read https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html right, then we must make that flag volatile.