### PR TITLE
add storage format version in case we make further format changes in future

### DIFF
--- a/core/src/main/java/overflowdb/storage/BackwardsCompatibilityError.java
+++ b/core/src/main/java/overflowdb/storage/BackwardsCompatibilityError.java
@@ -1,0 +1,7 @@
+package overflowdb.storage;
+
+public class BackwardsCompatibilityError extends RuntimeException {
+  public BackwardsCompatibilityError(String msg) {
+    super(msg);
+  }
+}

--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -63,7 +63,7 @@ public class OdbStorage implements AutoCloseable {
     if (mvstoreFileMaybe.isPresent()) {
       this.doPersist = true;
       mvstoreFile = mvstoreFileMaybe.get();
-      if (mvstoreFile.exists()) {
+      if (mvstoreFile.exists() && mvstoreFile.length() > 0) {
         verifyStorageVersion();
       }
     } else {

--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -15,6 +15,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class OdbStorage implements AutoCloseable {
+  /** when persistence format changes, increase this number - this protects us from attempting to open outdated formats */
+  public static final int STORAGE_FORMAT_VERSION = 1;
+  public static final String METADATA_KEY_STORAGE_FORMAT_VERSION = "STORAGE_FORMAT_VERSION";
+
   private static final String INDEX_PREFIX = "index_";
   private final Logger logger = LoggerFactory.getLogger(getClass());
   protected final NodeSerializer nodeSerializer;
@@ -24,6 +28,7 @@ public class OdbStorage implements AutoCloseable {
   private final boolean doPersist;
   private MVStore mvstore; // initialized in `getNodesMVMap`
   private MVMap<Long, byte[]> nodesMVMap;
+  private MVMap<String, String> metadataMVMap;
   private boolean closed;
 
   public static OdbStorage createWithTempFile(
@@ -58,6 +63,9 @@ public class OdbStorage implements AutoCloseable {
     if (mvstoreFileMaybe.isPresent()) {
       this.doPersist = true;
       mvstoreFile = mvstoreFileMaybe.get();
+      if (mvstoreFile.exists()) {
+        verifyStorageVersion();
+      }
     } else {
       try {
         this.doPersist = false;
@@ -68,6 +76,23 @@ public class OdbStorage implements AutoCloseable {
       }
     }
     logger.trace("storage file: " + mvstoreFile);
+  }
+
+  /** storage version must be exactly the same */
+  private void verifyStorageVersion() {
+    ensureMVStoreAvailable();
+    MVMap<String, String> metaData = getMetaDataMVMap();
+    if (!metaData.containsKey(METADATA_KEY_STORAGE_FORMAT_VERSION)) {
+      throw new BackwardsCompatibilityError("storage metadata does not contain version number, this must be an old format.");
+    }
+
+    String storageFormatVersionString = metaData.get(METADATA_KEY_STORAGE_FORMAT_VERSION);
+    int storageFormatVersion = Integer.parseInt(storageFormatVersionString);
+    if (storageFormatVersion != STORAGE_FORMAT_VERSION) {
+      throw new BackwardsCompatibilityError(String.format(
+          "attempting to open storage with different version: %s; this version of overflowdb requires the version to be exactly %s",
+          storageFormatVersion, STORAGE_FORMAT_VERSION));
+    }
   }
 
   public void persist(final NodeDb node) {
@@ -105,6 +130,7 @@ public class OdbStorage implements AutoCloseable {
   public void close() {
     closed = true;
     logger.debug("closing " + getClass().getSimpleName());
+    getMetaDataMVMap().put(METADATA_KEY_STORAGE_FORMAT_VERSION, String.format("%s", STORAGE_FORMAT_VERSION));
     flush();
     if (mvstore != null) mvstore.close();
     if (!doPersist) mvstoreFile.delete();
@@ -127,12 +153,23 @@ public class OdbStorage implements AutoCloseable {
   }
 
   public MVMap<Long, byte[]> getNodesMVMap() {
-    if (mvstore == null) {
-      mvstore = initializeMVStore();
-    }
+    ensureMVStoreAvailable();
     if (nodesMVMap == null)
       nodesMVMap = mvstore.openMap("nodes");
     return nodesMVMap;
+  }
+
+  public MVMap<String, String> getMetaDataMVMap() {
+    ensureMVStoreAvailable();
+    if (metadataMVMap == null)
+      metadataMVMap = mvstore.openMap("metadata");
+    return metadataMVMap;
+  }
+
+  private void ensureMVStoreAvailable() {
+    if (mvstore == null) {
+      mvstore = initializeMVStore();
+    }
   }
 
   private MVStore initializeMVStore() {
@@ -141,6 +178,7 @@ public class OdbStorage implements AutoCloseable {
         .autoCommitBufferSize(1024 * 8)
         .compress()
         .open();
+
     return store;
   }
 

--- a/core/src/test/java/overflowdb/storage/BackwardsCompatibilityTest.java
+++ b/core/src/test/java/overflowdb/storage/BackwardsCompatibilityTest.java
@@ -36,7 +36,6 @@ public class BackwardsCompatibilityTest {
   @Test
   public void shouldLoadOldStorageFormatWhenAddingEdgeType() throws IOException {
     final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
-    storageFile.delete();
     Config config = Config.withDefaults().withStorageLocation(storageFile.getAbsolutePath());
 
     final long thing1Id;
@@ -77,7 +76,6 @@ public class BackwardsCompatibilityTest {
    *  */
   public void shouldThrowExceptionForUnsupportedProperty() throws IOException {
     final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
-    storageFile.delete();
     Config config = Config.withDefaults().withStorageLocation(storageFile.getAbsolutePath());
 
     {
@@ -107,7 +105,6 @@ public class BackwardsCompatibilityTest {
    *  */
   public void shouldThrowExceptionForUnsupportedEdge() throws IOException {
     final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
-    storageFile.delete();
     Config config = Config.withDefaults().withStorageLocation(storageFile.getAbsolutePath());
 
     {

--- a/core/src/test/java/overflowdb/storage/OdbStorageTest.java
+++ b/core/src/test/java/overflowdb/storage/OdbStorageTest.java
@@ -66,7 +66,6 @@ public class OdbStorageTest {
   @Test(expected = BackwardsCompatibilityError.class)
   public void shouldErrorWhenTryingToOpenWithoutStorageFormatVersion() throws IOException {
     File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
-    storageFile.delete();
     storageFile.deleteOnExit();
     OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, false);
     storage.close();
@@ -84,7 +83,6 @@ public class OdbStorageTest {
   @Test(expected = BackwardsCompatibilityError.class)
   public void shouldErrorWhenTryingToOpenDifferentStorageFormatVersion() throws IOException {
     File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
-    storageFile.delete();
     storageFile.deleteOnExit();
     OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, false);
     storage.close();

--- a/core/src/test/java/overflowdb/storage/OdbStorageTest.java
+++ b/core/src/test/java/overflowdb/storage/OdbStorageTest.java
@@ -1,5 +1,7 @@
 package overflowdb.storage;
 
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
 import org.junit.Test;
 import overflowdb.Node;
 import overflowdb.Config;
@@ -60,5 +62,42 @@ public class OdbStorageTest {
 
     assertFalse("temp storage file should be deleted on close", tmpStorageFile.exists());
   }
+
+  @Test(expected = BackwardsCompatibilityError.class)
+  public void shouldErrorWhenTryingToOpenWithoutStorageFormatVersion() throws IOException {
+    File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
+    storageFile.delete();
+    storageFile.deleteOnExit();
+    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, false);
+    storage.close();
+
+    // modify storage: drop storage version
+    MVStore store = new MVStore.Builder().fileName(storageFile.getAbsolutePath()).open();
+    final MVMap<String, String> metadata = store.openMap("metadata");
+    metadata.remove(OdbStorage.METADATA_KEY_STORAGE_FORMAT_VERSION);
+    store.close();
+
+    // should throw a BackwardsCompatibilityError
+    OdbStorage.createWithSpecificLocation(storageFile, false);
+  }
+
+  @Test(expected = BackwardsCompatibilityError.class)
+  public void shouldErrorWhenTryingToOpenDifferentStorageFormatVersion() throws IOException {
+    File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
+    storageFile.delete();
+    storageFile.deleteOnExit();
+    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, false);
+    storage.close();
+
+    // modify storage: change storage version
+    MVStore store = new MVStore.Builder().fileName(storageFile.getAbsolutePath()).open();
+    final MVMap<String, String> metadata = store.openMap("metadata");
+    metadata.put(OdbStorage.METADATA_KEY_STORAGE_FORMAT_VERSION, "-1");
+    store.close();
+
+    // should throw a BackwardsCompatibilityError
+    OdbStorage.createWithSpecificLocation(storageFile, false);
+  }
+
 
 }


### PR DESCRIPTION
these changes are quite rare (we kept the initial format for almost
two years), but if they happen it's good to fail early and let the user
know