### PR TITLE
write int not strings for compactness, and some refactorings

### DIFF
--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -61,14 +61,12 @@ public final class Graph implements AutoCloseable {
     this.nodeFactoryByLabel = nodeFactoryByLabel;
     this.edgeFactoryByLabel = edgeFactoryByLabel;
 
-    if (config.getStorageLocation().isPresent()) {
-      storage = OdbStorage.createWithSpecificLocation(new File(config.getStorageLocation().get()));
-      initElementCollections(storage);
-    } else {
-      storage = OdbStorage.createWithTempFile();
-    }
+    storage = config.getStorageLocation().isPresent()
+        ? OdbStorage.createWithSpecificLocation(new File(config.getStorageLocation().get()))
+        : OdbStorage.createWithTempFile();
     this.nodeDeserializer = new NodeDeserializer(this, nodeFactoryByLabelId, config.isSerializationStatsEnabled(), storage);
     this.nodeSerializer = new NodeSerializer(config.isSerializationStatsEnabled(), storage);
+    config.getStorageLocation().ifPresent(l -> initElementCollections(storage));
     referenceManager = new ReferenceManager(storage);
     heapUsageMonitor = config.isOverflowEnabled() ?
         Optional.of(new HeapUsageMonitor(config.getHeapPercentageThreshold(), referenceManager)) :

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -63,7 +63,11 @@ public abstract class NodeRef<N extends NodeDb> implements Node {
   protected byte[] serializeWhenDirty() {
     NodeDb node = this.node;
     if (node != null && node.isDirty()) {
-      return graph.storage.serialize(node);
+      try {
+        return graph.nodeSerializer.serialize(node);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
     return null;
   }
@@ -111,7 +115,8 @@ public abstract class NodeRef<N extends NodeDb> implements Node {
   }
 
   private final N readFromDisk(long nodeId) throws IOException {
-    return graph.storage.readNode(nodeId);
+    byte[] bytes = graph.storage.getSerializedNode(nodeId);
+    return (N) graph.nodeDeserializer.deserialize(bytes);
   }
 
   public long id() {

--- a/core/src/main/java/overflowdb/storage/NodeDeserializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeDeserializer.java
@@ -139,21 +139,6 @@ public class NodeDeserializer extends BookKeeper {
     }
   }
 
-  protected final Object[] toKeyValueArray(Map<String, Object> properties) {
-    List keyValues = new ArrayList(properties.size() * 2); // may grow bigger if there's list entries
-    for (Map.Entry<String, Object> entry : properties.entrySet()) {
-      //todo: We fail to properly intern strings contained in a List.
-      final String key = intern(entry.getKey());
-      final Object property = entry.getValue();
-      keyValues.add(key);
-      if(property instanceof String)
-        keyValues.add(intern((String)property));
-      else
-        keyValues.add(property);
-    }
-    return keyValues.toArray();
-  }
-
   protected final NodeRef createNodeRef(long id, int labelId) {
     return getNodeFactory(labelId).createNodeRef(graph, id);
   }

--- a/core/src/main/java/overflowdb/storage/NodeDeserializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeDeserializer.java
@@ -22,11 +22,13 @@ public class NodeDeserializer extends BookKeeper {
   protected final Graph graph;
   private final Map<Integer, NodeFactory> nodeFactoryByLabelId;
   private ConcurrentHashMap<String, String> interner;
+  private final OdbStorage storage;
 
-  public NodeDeserializer(Graph graph, Map<Integer, NodeFactory> nodeFactoryByLabelId, boolean statsEnabled) {
+  public NodeDeserializer(Graph graph, Map<Integer, NodeFactory> nodeFactoryByLabelId, boolean statsEnabled, OdbStorage storage) {
     super(statsEnabled);
     this.graph = graph;
     this.nodeFactoryByLabelId = nodeFactoryByLabelId;
+    this.storage = storage;
     this.interner = new ConcurrentHashMap<>();
   }
 
@@ -60,7 +62,8 @@ public class NodeDeserializer extends BookKeeper {
   private void deserializeEdges(MessageUnpacker unpacker, NodeDb node, Direction direction) throws IOException {
     int edgeTypesCount = unpacker.unpackInt();
     for (int edgeTypeIdx = 0; edgeTypeIdx < edgeTypesCount; edgeTypeIdx++) {
-      String edgeLabel = unpacker.unpackString();
+      int edgeLabelId = unpacker.unpackInt();
+      String edgeLabel = storage.reverseLookupStringToIntMapping(edgeLabelId);
       int edgeCount = unpacker.unpackInt();
       for (int edgeIdx = 0; edgeIdx < edgeCount; edgeIdx++) {
         long adjancentNodeId = unpacker.unpackLong();
@@ -88,7 +91,8 @@ public class NodeDeserializer extends BookKeeper {
     Object[] res = new Object[propertyCount * 2];
     int resIdx = 0;
     for (int propertyIdx = 0; propertyIdx < propertyCount; propertyIdx++) {
-      final String key = intern(unpacker.unpackString());
+      int keyId = unpacker.unpackInt();
+      final String key = intern(storage.reverseLookupStringToIntMapping(keyId));
       final Object unpackedProperty = unpackValue(unpacker.unpackValue().asArrayValue());
       res[resIdx++] = key;
       res[resIdx++] = unpackedProperty;

--- a/core/src/test/java/overflowdb/storage/OdbStorageTest.java
+++ b/core/src/test/java/overflowdb/storage/OdbStorageTest.java
@@ -67,7 +67,7 @@ public class OdbStorageTest {
   public void shouldErrorWhenTryingToOpenWithoutStorageFormatVersion() throws IOException {
     File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
     storageFile.deleteOnExit();
-    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, false);
+    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile);
     storage.close();
 
     // modify storage: drop storage version
@@ -77,14 +77,14 @@ public class OdbStorageTest {
     store.close();
 
     // should throw a BackwardsCompatibilityError
-    OdbStorage.createWithSpecificLocation(storageFile, false);
+    OdbStorage.createWithSpecificLocation(storageFile);
   }
 
   @Test(expected = BackwardsCompatibilityError.class)
   public void shouldErrorWhenTryingToOpenDifferentStorageFormatVersion() throws IOException {
     File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
     storageFile.deleteOnExit();
-    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, false);
+    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile);
     storage.close();
 
     // modify storage: change storage version
@@ -94,7 +94,7 @@ public class OdbStorageTest {
     store.close();
 
     // should throw a BackwardsCompatibilityError
-    OdbStorage.createWithSpecificLocation(storageFile, false);
+    OdbStorage.createWithSpecificLocation(storageFile);
   }
 
   @Test
@@ -102,7 +102,7 @@ public class OdbStorageTest {
     File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
     storageFile.delete();
     storageFile.deleteOnExit();
-    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, false);
+    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile);
 
     String a = "a";
     String b = "b";
@@ -119,7 +119,7 @@ public class OdbStorageTest {
 
     // should survive restarts
     storage.close();
-    storage = OdbStorage.createWithSpecificLocation(storageFile, false);
+    storage = OdbStorage.createWithSpecificLocation(storageFile);
     assertEquals(stringIdA, storage.lookupOrCreateStringToIntMapping(a));
     assertEquals(stringIdB, storage.lookupOrCreateStringToIntMapping(b));
 

--- a/core/src/test/java/overflowdb/storage/OdbStorageTest.java
+++ b/core/src/test/java/overflowdb/storage/OdbStorageTest.java
@@ -97,5 +97,31 @@ public class OdbStorageTest {
     OdbStorage.createWithSpecificLocation(storageFile, false);
   }
 
+  @Test
+  public void shouldProvideStringToIntGlossary() throws IOException {
+    File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
+    storageFile.delete();
+    storageFile.deleteOnExit();
+    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, false);
+
+    String a = "a";
+    String b = "b";
+    Integer stringIdA = storage.lookupOrCreateGlossaryEntry(a);
+    Integer stringIdB = storage.lookupOrCreateGlossaryEntry(b);
+
+    // should be idempotent
+    assertEquals(stringIdA, storage.lookupOrCreateGlossaryEntry(a));
+    assertEquals(stringIdB, storage.lookupOrCreateGlossaryEntry(b));
+
+    // should survive restarts
+    storage.close();
+    storage = OdbStorage.createWithSpecificLocation(storageFile, false);
+    assertEquals(stringIdA, storage.lookupOrCreateGlossaryEntry(a));
+    assertEquals(stringIdB, storage.lookupOrCreateGlossaryEntry(b));
+
+    Integer stringIdC = storage.lookupOrCreateGlossaryEntry("c");
+    assertEquals(3, storage.getStringGlossary().size());
+  }
+
 
 }

--- a/core/src/test/java/overflowdb/storage/OdbStorageTest.java
+++ b/core/src/test/java/overflowdb/storage/OdbStorageTest.java
@@ -106,21 +106,22 @@ public class OdbStorageTest {
 
     String a = "a";
     String b = "b";
-    Integer stringIdA = storage.lookupOrCreateGlossaryEntry(a);
-    Integer stringIdB = storage.lookupOrCreateGlossaryEntry(b);
+    String c = "c";
+    int stringIdA = storage.lookupOrCreateStringToIntMapping(a);
+    int stringIdB = storage.lookupOrCreateStringToIntMapping(b);
 
     // should be idempotent
-    assertEquals(stringIdA, storage.lookupOrCreateGlossaryEntry(a));
-    assertEquals(stringIdB, storage.lookupOrCreateGlossaryEntry(b));
+    assertEquals(stringIdA, storage.lookupOrCreateStringToIntMapping(a));
+    assertEquals(stringIdB, storage.lookupOrCreateStringToIntMapping(b));
 
     // should survive restarts
     storage.close();
     storage = OdbStorage.createWithSpecificLocation(storageFile, false);
-    assertEquals(stringIdA, storage.lookupOrCreateGlossaryEntry(a));
-    assertEquals(stringIdB, storage.lookupOrCreateGlossaryEntry(b));
+    assertEquals(stringIdA, storage.lookupOrCreateStringToIntMapping(a));
+    assertEquals(stringIdB, storage.lookupOrCreateStringToIntMapping(b));
 
-    Integer stringIdC = storage.lookupOrCreateGlossaryEntry("c");
-    assertEquals(3, storage.getStringGlossary().size());
+    int stringIdC = storage.lookupOrCreateStringToIntMapping(c);
+    assertEquals(3, storage.getStringToIntMappings().size());
   }
 
 

--- a/core/src/test/java/overflowdb/storage/OdbStorageTest.java
+++ b/core/src/test/java/overflowdb/storage/OdbStorageTest.java
@@ -107,10 +107,13 @@ public class OdbStorageTest {
     String a = "a";
     String b = "b";
     String c = "c";
+
     int stringIdA = storage.lookupOrCreateStringToIntMapping(a);
     int stringIdB = storage.lookupOrCreateStringToIntMapping(b);
+    assertEquals(a, storage.reverseLookupStringToIntMapping(stringIdA));
+    assertEquals(b, storage.reverseLookupStringToIntMapping(stringIdB));
 
-    // should be idempotent
+    // should be idempotent - i.e. should not create additional entries
     assertEquals(stringIdA, storage.lookupOrCreateStringToIntMapping(a));
     assertEquals(stringIdB, storage.lookupOrCreateStringToIntMapping(b));
 
@@ -122,6 +125,10 @@ public class OdbStorageTest {
 
     int stringIdC = storage.lookupOrCreateStringToIntMapping(c);
     assertEquals(3, storage.getStringToIntMappings().size());
+
+    assertEquals(a, storage.reverseLookupStringToIntMapping(stringIdA));
+    assertEquals(b, storage.reverseLookupStringToIntMapping(stringIdB));
+    assertEquals(c, storage.reverseLookupStringToIntMapping(stringIdC));
   }
 
 

--- a/core/src/test/java/overflowdb/storage/SerializerTest.java
+++ b/core/src/test/java/overflowdb/storage/SerializerTest.java
@@ -23,7 +23,7 @@ public class SerializerTest {
   @Test
   public void serializeNode() throws IOException {
     try (Graph graph = SimpleDomain.newGraph()) {
-      NodeSerializer serializer = new NodeSerializer(false);
+      NodeSerializer serializer = new NodeSerializer(false, graph.getStorage());
       NodeDeserializer deserializer = newDeserializer(graph);
       TestNode testNode = (TestNode) graph.addNode(
           TestNode.LABEL,
@@ -50,7 +50,7 @@ public class SerializerTest {
   @Test
   public void serializeWithEdge() throws IOException {
     try (Graph graph = SimpleDomain.newGraph()) {
-      NodeSerializer serializer = new NodeSerializer(true);
+      NodeSerializer serializer = new NodeSerializer(true, graph.getStorage());
       NodeDeserializer deserializer = newDeserializer(graph);
 
       TestNode testNode1 = (TestNode) graph.addNode(TestNode.LABEL);
@@ -80,7 +80,7 @@ public class SerializerTest {
   private NodeDeserializer newDeserializer(Graph graph) {
     Map<Integer, NodeFactory> nodeFactories = new HashMap();
     nodeFactories.put(TestNodeDb.layoutInformation.labelId, TestNode.factory);
-    return new NodeDeserializer(graph, nodeFactories, true);
+    return new NodeDeserializer(graph, nodeFactories, true, null);
   }
 
 }

--- a/core/src/test/java/overflowdb/storage/SerializerTest.java
+++ b/core/src/test/java/overflowdb/storage/SerializerTest.java
@@ -80,7 +80,7 @@ public class SerializerTest {
   private NodeDeserializer newDeserializer(Graph graph) {
     Map<Integer, NodeFactory> nodeFactories = new HashMap();
     nodeFactories.put(TestNodeDb.layoutInformation.labelId, TestNode.factory);
-    return new NodeDeserializer(graph, nodeFactories, true, null);
+    return new NodeDeserializer(graph, nodeFactories, true, graph.getStorage());
   }
 
 }

--- a/tinkerpop3/src/test/java/overflowdb/storage/GraphSaveRestoreTest.java
+++ b/tinkerpop3/src/test/java/overflowdb/storage/GraphSaveRestoreTest.java
@@ -177,7 +177,7 @@ public class GraphSaveRestoreTest {
     Graph graph = openGratefulDeadGraph(storageFile, false);
     int expectedSerializationCount = graphModifications.apply(graph);
     graph.close();
-    assertEquals(expectedSerializationCount, graph.getStorage().nodeSerializer.getSerializedCount());
+    assertEquals(expectedSerializationCount, graph.nodeSerializer.getSerializedCount());
   }
 
   private Graph openGratefulDeadGraph(File overflowDb, boolean enableOverflow) {


### PR DESCRIPTION
* move (de)serializer out of storage for simplicity, adapt init order
* treat empty and non-existent storage files the same

note: contains https://github.com/ShiftLeftSecurity/overflowdb/pull/169 - review/merge that one first