### PR TITLE
library version metadata to enable version compatibility handling

### DIFF
--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -12,8 +12,8 @@ import overflowdb.util.PropertyHelper;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -317,7 +317,7 @@ public final class Graph implements AutoCloseable {
     storage.persistLibraryVersion(name, version);
   }
 
-  public Collection<Map<String, String>> getAllLibraryVersions() {
+  public ArrayList<Map<String, String>> getAllLibraryVersions() {
     return storage.getAllLibraryVersions();
   }
 }

--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -13,6 +13,7 @@ import overflowdb.util.PropertyHelper;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -61,6 +62,7 @@ public final class Graph implements AutoCloseable {
     storage = config.getStorageLocation().isPresent()
         ? OdbStorage.createWithSpecificLocation(new File(config.getStorageLocation().get()))
         : OdbStorage.createWithTempFile();
+    persistLibraryVersion(getClass());
     this.nodeDeserializer = new NodeDeserializer(this, nodeFactoryByLabel, config.isSerializationStatsEnabled(), storage);
     this.nodeSerializer = new NodeSerializer(config.isSerializationStatsEnabled(), storage);
     config.getStorageLocation().ifPresent(l -> initElementCollections(storage));
@@ -307,4 +309,15 @@ public final class Graph implements AutoCloseable {
       return ((NodeRef) node).get();
   }
 
+  public void persistLibraryVersion(Class clazz) {
+    storage.persistLibraryVersion(clazz);
+  }
+
+  public void persistLibraryVersion(String name, String version) {
+    storage.persistLibraryVersion(name, version);
+  }
+
+  public Collection<Map<String, String>> getAllLibraryVersions() {
+    return storage.getAllLibraryVersions();
+  }
 }

--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -9,7 +9,6 @@ import overflowdb.util.StringInterner;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -269,7 +268,7 @@ public class OdbStorage implements AutoCloseable {
     getMetaDataMVMap().put(key, version);
   }
 
-  public Collection<Map<String, String>> getAllLibraryVersions() {
+  public ArrayList<Map<String, String>> getAllLibraryVersions() {
     Map<Integer, Map<String, String>> libraryVersionsByRunId = new HashMap<>();
     getMetaDataMVMap().forEach((key, version) -> {
       if (key.startsWith(METADATA_PREFIX_LIBRARY_VERSIONS)) {
@@ -282,6 +281,6 @@ public class OdbStorage implements AutoCloseable {
       }
     });
 
-    return libraryVersionsByRunId.values();
+    return new ArrayList<>(libraryVersionsByRunId.values());
   }
 }

--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -9,6 +9,8 @@ import overflowdb.util.StringInterner;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -22,6 +24,8 @@ public class OdbStorage implements AutoCloseable {
 
   public static final String METADATA_KEY_STORAGE_FORMAT_VERSION = "STORAGE_FORMAT_VERSION";
   public static final String METADATA_KEY_STRING_TO_INT_MAX_ID = "STRING_TO_INT_MAX_ID";
+  public static final String METADATA_KEY_LIBRARY_VERSIONS_MAX_ID = "LIBRARY_VERSIONS_MAX_ID";
+  public static final String METADATA_PREFIX_LIBRARY_VERSIONS = "LIBRARY_VERSIONS_ENTRY_";
   private static final String INDEX_PREFIX = "index_";
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -35,6 +39,7 @@ public class OdbStorage implements AutoCloseable {
   private boolean closed;
   private final AtomicInteger stringToIntMappingsMaxId = new AtomicInteger(0);
   private ArrayList<String> stringToIntReverseMappings;
+  private final int libraryVersionsIdCurrentRun;
 
   public static OdbStorage createWithTempFile() {
     return new OdbStorage(Optional.empty());
@@ -65,7 +70,21 @@ public class OdbStorage implements AutoCloseable {
         throw new RuntimeException("cannot create tmp file for mvstore", e);
       }
     }
+    this.libraryVersionsIdCurrentRun = initializeLibraryVersionsIdCurrentRun();
     logger.trace("storage file: " + mvstoreFile);
+  }
+
+  private int initializeLibraryVersionsIdCurrentRun() {
+    MVMap<String, String> metaData = getMetaDataMVMap();
+    final int res;
+    if (metaData.containsKey(METADATA_KEY_LIBRARY_VERSIONS_MAX_ID)) {
+      res = Integer.parseInt(metaData.get(METADATA_KEY_LIBRARY_VERSIONS_MAX_ID)) + 1;
+    } else {
+      res = 0;
+    }
+
+    metaData.put(METADATA_KEY_LIBRARY_VERSIONS_MAX_ID, "" + res);
+    return res;
   }
 
   private void initializeStringToIntMaxId() {
@@ -238,5 +257,31 @@ public class OdbStorage implements AutoCloseable {
 
   public byte[] getSerializedNode(long nodeId) {
     return getNodesMVMap().get(nodeId);
+  }
+
+  public void persistLibraryVersion(Class clazz) {
+    String version = clazz.getPackage().getImplementationVersion();
+    if (version != null) persistLibraryVersion(clazz.getCanonicalName(), version);
+  }
+
+  public void persistLibraryVersion(String name, String version) {
+    String key = String.format("%s%d_%s", METADATA_PREFIX_LIBRARY_VERSIONS, libraryVersionsIdCurrentRun, name);
+    getMetaDataMVMap().put(key, version);
+  }
+
+  public Collection<Map<String, String>> getAllLibraryVersions() {
+    Map<Integer, Map<String, String>> libraryVersionsByRunId = new HashMap<>();
+    getMetaDataMVMap().forEach((key, version) -> {
+      if (key.startsWith(METADATA_PREFIX_LIBRARY_VERSIONS)) {
+        String withoutPrefix = key.substring(METADATA_PREFIX_LIBRARY_VERSIONS.length());
+        int firstDividerIndex = withoutPrefix.indexOf('_');
+        int runId = Integer.parseInt(withoutPrefix.substring(0, firstDividerIndex));
+        String library = withoutPrefix.substring(firstDividerIndex + 1);
+        Map<String, String> versionInfos = libraryVersionsByRunId.computeIfAbsent(runId, i -> new HashMap<>());
+        versionInfos.put(library, version);
+      }
+    });
+
+    return libraryVersionsByRunId.values();
   }
 }

--- a/core/src/test/java/overflowdb/LibraryVersionsTest.java
+++ b/core/src/test/java/overflowdb/LibraryVersionsTest.java
@@ -1,0 +1,59 @@
+package overflowdb;
+
+import org.junit.Test;
+import overflowdb.testdomains.gratefuldead.GratefulDead;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class LibraryVersionsTest {
+
+  @Test
+  public void persistsRandomLibraryVersions() {
+    Graph graph = GratefulDead.newGraph();
+    graph.persistLibraryVersion("example.Foo1", "1.2.3");
+    graph.persistLibraryVersion("example.Foo2", "4.5_SNAPSHOT");
+
+    Collection<Map<String, String>> allVersions = graph.getAllLibraryVersions();
+    assertEquals(1, allVersions.size());
+    Map<String, String> versions = allVersions.iterator().next();
+    assertEquals("1.2.3", versions.get("example.Foo1"));
+    assertEquals("4.5_SNAPSHOT", versions.get("example.Foo2"));
+  }
+
+  @Test
+  public void persistsNewSetOfLibraryVersionsAfterRestart() throws IOException {
+    final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
+    Config config = Config.withDefaults().withStorageLocation(storageFile.getAbsolutePath());
+
+    Graph graph = GratefulDead.newGraph(config);
+    graph.persistLibraryVersion("example.Foo1", "1.2.3");
+    graph.persistLibraryVersion("example.Foo2", "4.5_SNAPSHOT");
+    graph.close();
+
+    // adding more versions after restart: graph should preserve both old and new set of versions independently
+    graph = GratefulDead.newGraph(config);
+    graph.persistLibraryVersion("example.Foo1", "1.2.4");
+    graph.persistLibraryVersion("example.Foo2", "4.6_SNAPSHOT");
+    Collection<Map<String, String>> allVersions = graph.getAllLibraryVersions();
+    assertEquals(2, allVersions.size());
+
+    Iterator<Map<String, String>> versionsIter = allVersions.iterator();
+    Map<String, String> versions = versionsIter.next();
+    assertEquals("1.2.3", versions.get("example.Foo1"));
+    assertEquals("4.5_SNAPSHOT", versions.get("example.Foo2"));
+
+    versions = versionsIter.next();
+    assertEquals("1.2.4", versions.get("example.Foo1"));
+    assertEquals("4.6_SNAPSHOT", versions.get("example.Foo2"));
+
+    graph.close();
+  }
+
+}


### PR DESCRIPTION
* allows to register random versions for any potentially relevant library
* persists new set of versions across restarts
* automatically persists overflowdb version
* re https://github.com/ShiftLeftSecurity/overflowdb/pull/172#issuecomment-720324614