### PR TITLE
serializer: bring back support for node ids in unpack/pack values

### DIFF
--- a/core/src/main/java/overflowdb/storage/NodeDeserializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeDeserializer.java
@@ -103,6 +103,9 @@ public class NodeDeserializer extends BookKeeper {
     switch (ValueTypes.lookup(valueTypeId)) {
       case UNKNOWN:
         return null;
+      case NODE_REF:
+        long id = value.asIntegerValue().asLong();
+        return graph.node(id);
       case BOOLEAN:
         return value.asBooleanValue().getBoolean();
       case STRING:

--- a/core/src/main/java/overflowdb/storage/NodeSerializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeSerializer.java
@@ -3,6 +3,7 @@ package overflowdb.storage;
 import overflowdb.Node;
 import overflowdb.NodeLayoutInformation;
 import overflowdb.NodeDb;
+import overflowdb.NodeRef;
 import org.msgpack.core.MessageBufferPacker;
 import org.msgpack.core.MessagePack;
 
@@ -139,6 +140,9 @@ public class NodeSerializer extends BookKeeper {
     if (value == null) {
       packer.packByte(ValueTypes.UNKNOWN.id);
       packer.packNil();
+    } else if (value instanceof NodeRef) {
+      packer.packByte(ValueTypes.NODE_REF.id);
+      packer.packLong(((NodeRef) value).id());
     } else if (value instanceof Boolean) {
       packer.packByte(ValueTypes.BOOLEAN.id);
       packer.packBoolean((Boolean) value);


### PR DESCRIPTION
i removed this because i thought it wasn't needed, but turns out it is