### PR TITLE
speed up some traversals

### DIFF
--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -12,15 +12,7 @@ import overflowdb.util.PropertyHelper;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
@@ -260,7 +252,7 @@ public final class Graph implements AutoCloseable {
   }
 
   private final void addNodesToMultiIterator(final MultiIterator<Node> multiIterator, final String label) {
-    final Set<Node> ret = nodes.nodesByLabel(label);
+    final Collection<Node> ret = nodes.nodesByLabel(label);
     if (ret != null) {
       multiIterator.addIterator(ret.iterator());
     }

--- a/core/src/main/java/overflowdb/util/NodesList.java
+++ b/core/src/main/java/overflowdb/util/NodesList.java
@@ -53,8 +53,9 @@ public class NodesList {
 
     nodes[index] = node;
     nodeIndexByNodeId.put(node.id(), index);
-    if(nodesByLabel != null)
+    if(nodesByLabel != null) {
       nodesByLabel(node.label()).add(node);
+    }
     size++;
   }
 
@@ -109,11 +110,12 @@ public class NodesList {
     TMap<String, ArrayList<Node>> tmp = new THashMap<>();
     for(Node node: nodes){
       if(node != null){
-        tmp.compute(node.label(), (k,v)->{
-          ArrayList<Node> nodelist = (v==null? new ArrayList<Node>(): v);
-          nodelist.add(node);
-          return nodelist;
-        });
+        ArrayList<Node> nodelist = tmp.get(node.label());
+        if(nodelist == null){
+          nodelist = new ArrayList<>();
+          tmp.put(node.label(), nodelist);
+        }
+        nodelist.add(node);
       }
     }
     this.nodesByLabel = tmp;
@@ -121,7 +123,12 @@ public class NodesList {
 
   public ArrayList<Node> nodesByLabel(String label) {
     if(nodesByLabel == null) refreshNodesByLabel();
-    return nodesByLabel.compute(label, (k, v) -> (v == null ? new ArrayList<>() : v));
+    ArrayList<Node> nodelist = nodesByLabel.get(label);
+    if(nodelist == null){
+      nodelist = new ArrayList<>();
+      nodesByLabel.put(label, nodelist);
+    }
+    return nodelist;
   }
 
   public Set<String> nodeLabels() {

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -4,6 +4,7 @@ import org.slf4j.LoggerFactory
 import overflowdb.traversal.help.{Doc, TraversalHelp}
 
 import scala.collection.{Iterable, IterableFactory, IterableFactoryDefaults, IterableOnce, IterableOps, Iterator, mutable}
+import scala.collection.immutable.ArraySeq
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
@@ -52,7 +53,7 @@ class Traversal[A](elements: IterableOnce[A])
     * @see {{{collectAll}}} as a safe alternative */
   @Doc("casts all elements to given type")
   def cast[B]: Traversal[B] =
-    mapElements(_.asInstanceOf[B])
+    this.asInstanceOf[Traversal[B]]
 
   /** collects and all elements of the given type */
   @Doc("collects and all elements of the provided type")
@@ -248,12 +249,12 @@ class Traversal[A](elements: IterableOnce[A])
   /** sort elements by their natural order */
   @Doc("sort elements by their natural order")
   def sorted(implicit ord: Ordering[A]): Seq[A] =
-    elements.to(Seq).sorted
+    elements.to(ArraySeq.untagged).sorted
 
   /** sort elements by the value of the given transformation function */
   @Doc("sort elements by the value of the given transformation function")
   def sortBy[B](f: A => B)(implicit ord: Ordering[B]): Seq[A] =
-    elements.to(Seq).sortBy(f)
+    elements.to(ArraySeq.untagged).sortBy(f)
 
   /** group elements and count how often they appear */
   @Doc("group elements and count how often they appear")


### PR DESCRIPTION
This speeds up some traversals:

The most important one is that by-label now is in an arraylist. This gives very large speed-ups compared to Set. (what I think happens is that all the missed branches from empty slots in the gnu-THashSet reduce the efficiency of speculative execution as prefetcher. Alternatively, there might be something with inlining heuristics in the JIT. Irregardless, the speedup is much larger than the 20 cycles from a mispredicted branch) 

Further, `cast` can be sped up/simplified. `List` is the worst possible implementation of `Seq`, so let's use something less crazy.

Together with https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/32 I observe ~10% speedup for cpg2sp, on my eclectic collection of benchmark projects.