### PR TITLE
fix adjacency list bug

### DIFF
--- a/core/src/main/java/overflowdb/NodeDb.java
+++ b/core/src/main/java/overflowdb/NodeDb.java
@@ -625,7 +625,9 @@ public abstract class NodeDb implements Node {
     int strideSize = getStrideSize(edgeLabel);
 
     int insertAt = start + length;
-    if (adjacentNodesWithEdgeProperties.length <= insertAt || adjacentNodesWithEdgeProperties[insertAt] != null) {
+    if (adjacentNodesWithEdgeProperties.length <= insertAt
+            || adjacentNodesWithEdgeProperties[insertAt] != null
+            || (offsetPos + 1 < (edgeOffsets.length()>>1) && insertAt >= startIndex(offsetPos + 1))) {
       // space already occupied - grow adjacentNodesWithEdgeProperties array, leaving some room for more elements
       adjacentNodesWithEdgeProperties = growAdjacentNodesWithEdgeProperties(offsetPos, strideSize, insertAt, length);
     }


### PR DESCRIPTION
fix adjacency list bug: If the first neighbor in one adjacency-class gets deleted, then the preceding adjacency class may grow into this slot, leading to overlapping adjacency classes and bugs

fixes https://github.com/ShiftLeftSecurity/codepropertygraph/issues/1028

Apart from the (urgent) bugfix, I'd like to schedule a zoom / postmortem for this. 

Overflowdb was never designed; instead, it was grown from tinkerpop via drive-by-patches. The tinkerpop API is braindead enough that a clean and performant implementation is probably fundamentally impossible. Now that we don't rely on gremlin anymore, and therefore control the entire API, I think it is time to replace this super fragile and slow code by something less rickety.