### PR TITLE
next/nextOption should have parens since they are side effecty

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/PathAwareRepeatStep.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/PathAwareRepeatStep.scala
@@ -37,10 +37,10 @@ object PathAwareRepeatStep {
         while (worklist.nonEmpty && !stop) {
           val WorklistItem(trav0, depth) = worklist.head
           val trav = trav0.path
-          if (trav.isEmpty) worklist.removeHead
+          if (trav.isEmpty) worklist.removeHead()
           else if (behaviour.timesReached(depth)) stop = true
           else {
-            val path0 = trav.next
+            val path0 = trav.next()
             val (path1, elementInSeq) = path0.splitAt(path0.size - 1)
             val element = elementInSeq.head.asInstanceOf[A]
             if (behaviour.dedupEnabled) visited.addOne(element)
@@ -74,7 +74,7 @@ object PathAwareRepeatStep {
         val result = {
           if (emitSack.hasNext) emitSack.dequeue()
           else if (worklistTopHasNext) {
-            val entirePath = worklist.head.traversal.path.next
+            val entirePath = worklist.head.traversal.path.next()
             val (path, lastElement) = entirePath.splitAt(entirePath.size - 1)
             (lastElement.head.asInstanceOf[A], path)
           }

--- a/traversal/src/main/scala/overflowdb/traversal/RepeatStep.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/RepeatStep.scala
@@ -35,10 +35,10 @@ object RepeatStep {
         var stop = false
         while (worklist.nonEmpty && !stop) {
           val WorklistItem(trav, depth) = worklist.head
-          if (trav.isEmpty) worklist.removeHead
+          if (trav.isEmpty) worklist.removeHead()
           else if (behaviour.timesReached(depth)) stop = true
           else {
-            val element = trav.next
+            val element = trav.next()
             if (behaviour.dedupEnabled) visited.addOne(element)
             if (depth > 0  // `repeat/until` behaviour, i.e. only checking the `until` condition from depth 1
               && behaviour.untilConditionReached(element)) {
@@ -67,7 +67,7 @@ object RepeatStep {
           if (emitSack.hasNext)
             emitSack.dequeue()
           else if (worklistTopHasNext)
-            worklist.head.traversal.next
+            worklist.head.traversal.next()
           else throw new NoSuchElementException("next on empty iterator")
         }
         if (behaviour.dedupEnabled) visited.addOne(result)
@@ -82,7 +82,7 @@ object RepeatStep {
     def addItem(item: WorklistItem[A]): Unit
     def nonEmpty: Boolean
     def head: WorklistItem[A]
-    def removeHead: Unit
+    def removeHead(): Unit
   }
 
   /** stack based worklist for [[RepeatBehaviour.SearchAlgorithm.DepthFirst]] */
@@ -91,7 +91,7 @@ object RepeatStep {
     override def addItem(item: WorklistItem[A]) = stack.push(item)
     override def nonEmpty = stack.nonEmpty
     override def head = stack.top
-    override def removeHead = stack.pop()
+    override def removeHead() = stack.pop()
   }
 
   /** queue based worklist for [[RepeatBehaviour.SearchAlgorithm.BreadthFirst]] */
@@ -100,7 +100,7 @@ object RepeatStep {
     override def addItem(item: WorklistItem[A]) = queue.enqueue(item)
     override def nonEmpty = queue.nonEmpty
     override def head = queue.head
-    override def removeHead = queue.dequeue()
+    override def removeHead() = queue.dequeue()
   }
 
   case class WorklistItem[A](traversal: Traversal[A], depth: Int)

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -20,8 +20,8 @@ class Traversal[A](elements: IterableOnce[A])
     with IterableFactoryDefaults[A, Traversal] {
 
   def hasNext: Boolean = iterator.hasNext
-  def next: A = iterator.next()
-  def nextOption: Option[A] = iterator.nextOption()
+  def next(): A = iterator.next()
+  def nextOption(): Option[A] = iterator.nextOption()
 
   /** Execute the traversal and convert the result to a list - shorthand for `toList` */
   @Doc("Execute the traversal and convert the result to a list - shorthand for `toList`")
@@ -29,7 +29,7 @@ class Traversal[A](elements: IterableOnce[A])
 
   /** Execute the traversal without returning anything */
   @Doc("Execute the traversal without returning anything")
-  def iterate: Unit =
+  def iterate(): Unit =
     while (hasNext) next
 
   /**

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -30,7 +30,7 @@ class Traversal[A](elements: IterableOnce[A])
   /** Execute the traversal without returning anything */
   @Doc("Execute the traversal without returning anything")
   def iterate(): Unit =
-    while (hasNext) next
+    while (hasNext) next()
 
   /**
    * Print help/documentation based on the current elementType `A`.

--- a/traversal/src/test/scala/overflowdb/GraphSugarTests.scala
+++ b/traversal/src/test/scala/overflowdb/GraphSugarTests.scala
@@ -80,8 +80,8 @@ class GraphSugarTests extends WordSpec with Matchers {
       node1 --- (Connection.Label, Distance -> 10) --> node2
 
       node1.out(Connection.Label).next shouldBe node2
-      node1.outE(Connection.Label).property(Connection.Properties.Distance).next shouldBe 10
-      node1.outE(Connection.Label).property(Connection.PropertyNames.Distance).next shouldBe 10
+      node1.outE(Connection.Label).property(Connection.Properties.Distance).next() shouldBe 10
+      node1.outE(Connection.Label).property[Int](Connection.PropertyNames.Distance).next() shouldBe 10
     }
 
     "add an edge with multiple properties" in {

--- a/traversal/src/test/scala/overflowdb/traversal/RepeatTraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/RepeatTraversalTests.scala
@@ -219,14 +219,14 @@ class RepeatTraversalTests extends WordSpec with Matchers {
 
   "uses DFS (depth first search) by default" in {
     val traversedNodes = mutable.ListBuffer.empty[Thing]
-    centerTrav.repeat(_.sideEffect(traversedNodes.addOne).followedBy).iterate
+    centerTrav.repeat(_.sideEffect(traversedNodes.addOne).followedBy).iterate()
 
     traversedNodes.map(_.name).toList shouldBe List("Center", "L1", "L2", "L3", "R1", "R2", "R3", "R4", "R5")
   }
 
   "uses BFS (breadth first search) if configured" in {
     val traversedNodes = mutable.ListBuffer.empty[Thing]
-    centerTrav.repeat(_.sideEffect(traversedNodes.addOne).followedBy)(_.breadthFirstSearch).iterate
+    centerTrav.repeat(_.sideEffect(traversedNodes.addOne).followedBy)(_.breadthFirstSearch).iterate()
 
     traversedNodes.map(_.name).toList shouldBe List("Center", "L1", "R1", "L2", "R2", "L3", "R3", "R4", "R5")
   }

--- a/traversal/src/test/scala/overflowdb/traversal/TraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/TraversalTests.scala
@@ -70,7 +70,7 @@ class TraversalTests extends WordSpec with Matchers {
       /** using dedup by hash comparison, we can traverse over these elements - already consumed elements are garbage collected */
       val traversal = infiniteTraversalWithLargeElements.dedupBy(_.hashCode)
       0.to(128).foreach { i =>
-        traversal.next
+        traversal.next()
       }
 
       /** This is a copy of the above, but using the default dedup comparison style (hashAndEquals). To be able to
@@ -122,7 +122,7 @@ class TraversalTests extends WordSpec with Matchers {
 
   ".aggregate step stores all objects at this point into a given collection" in {
      val buffer = mutable.ArrayBuffer.empty[Thing]
-     center.start.followedBy.aggregate(buffer).followedBy.iterate
+     center.start.followedBy.aggregate(buffer).followedBy.iterate()
      buffer.toSet shouldBe Set(l1, r1)
   }
 


### PR DESCRIPTION
note: same goes for `.l` etc but since it's part of the core dsl,
conciseness wins over consistency in those cases