### PR TITLE
Disable auto commit.

### DIFF
--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -202,6 +202,7 @@ public class OdbStorage implements AutoCloseable {
         .fileName(mvstoreFile.getAbsolutePath())
         .autoCommitBufferSize(1024 * 8)
         .compress()
+        .autoCommitDisabled()
         .open();
 
     return store;


### PR DESCRIPTION
This avoids the creation of a background writer thread for MVStore.
That way CPG is not a resource which need to be closed.