### PR TITLE
only persist odb library version when really needed

### DIFF
--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -54,7 +54,6 @@ public final class Graph implements AutoCloseable {
     storage = config.getStorageLocation().isPresent()
         ? OdbStorage.createWithSpecificLocation(new File(config.getStorageLocation().get()))
         : OdbStorage.createWithTempFile();
-    persistLibraryVersion(getClass());
     this.nodeDeserializer = new NodeDeserializer(this, nodeFactoryByLabel, config.isSerializationStatsEnabled(), storage);
     this.nodeSerializer = new NodeSerializer(config.isSerializationStatsEnabled(), storage);
     config.getStorageLocation().ifPresent(l -> initElementCollections(storage));
@@ -299,10 +298,6 @@ public final class Graph implements AutoCloseable {
       return (NodeDb) node;
     else
       return ((NodeRef) node).get();
-  }
-
-  public void persistLibraryVersion(Class clazz) {
-    storage.persistLibraryVersion(clazz);
   }
 
   public void persistLibraryVersion(String name, String version) {

--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -193,6 +193,7 @@ public class OdbStorage implements AutoCloseable {
   private void ensureMVStoreAvailable() {
     if (mvstore == null) {
       mvstore = initializeMVStore();
+      persistOdbLibraryVersion();
       this.libraryVersionsIdCurrentRun = initializeLibraryVersionsIdCurrentRun();
     }
   }
@@ -259,7 +260,8 @@ public class OdbStorage implements AutoCloseable {
     return getNodesMVMap().get(nodeId);
   }
 
-  public void persistLibraryVersion(Class clazz) {
+  private void persistOdbLibraryVersion() {
+    Class clazz = getClass();
     String version = clazz.getPackage().getImplementationVersion();
     if (version != null) persistLibraryVersion(clazz.getCanonicalName(), version);
   }

--- a/core/src/test/java/overflowdb/GraphTest.java
+++ b/core/src/test/java/overflowdb/GraphTest.java
@@ -10,9 +10,17 @@ import overflowdb.testdomains.simple.SimpleDomain;
 import overflowdb.testdomains.simple.TestEdge;
 import overflowdb.testdomains.simple.TestNode;
 
+import java.util.ArrayList;
+
 import static org.junit.Assert.assertEquals;
 
 public class GraphTest {
+
+  public static void main(String[] args) throws InterruptedException {
+    Graph.open(Config.withoutOverflow(), new ArrayList<>(), new ArrayList<>());
+
+    Thread.sleep(1000000);
+  }
 
   @Test
   public void elementCounts() {


### PR DESCRIPTION
this delays mvstore initialisation - in many cases it's not even
required at all...