### PR TITLE
improve speed of NodeRef hashing

### DIFF
--- a/core/src/main/java/overflowdb/NodeDb.java
+++ b/core/src/main/java/overflowdb/NodeDb.java
@@ -754,12 +754,12 @@ public abstract class NodeDb implements Node {
      * The style (shift-xor 33 and multiply) is similar to murmur3; the multiply constant is randomly chosen odd number.
      * Feel free to change this.
      * */
-    long tmp = (id() ^ (id() >>> 33)) * 0x1ca213a8d7b7d9b1L;
+    long tmp = (id() ^ (id() >>> 33) ^ 0xc89f69faaa76b9b7L) * 0xa3ceded266465a8dL;
     return ((int) tmp) ^ ((int) (tmp >>> 32));
   }
 
   @Override
   public boolean equals(final Object obj) {
-    return (this == obj) || ( (obj instanceof Node) && id() == ((Node) obj).id() );
+    return (this == obj) || ( (obj instanceof NodeDb) && id() == ((Node) obj).id() );
   }
 }

--- a/core/src/main/java/overflowdb/NodeDb.java
+++ b/core/src/main/java/overflowdb/NodeDb.java
@@ -749,11 +749,17 @@ public abstract class NodeDb implements Node {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id());
+    /* NodeRef compares by id. We need the hash computation to be fast and allocation-free; but we don't need it
+     * very strong. Plain java would use id ^ (id>>>32) ; we do a little bit of mixing.
+     * The style (shift-xor 33 and multiply) is similar to murmur3; the multiply constant is randomly chosen odd number.
+     * Feel free to change this.
+     * */
+    long tmp = (id() ^ (id() >>> 33)) * 0x1ca213a8d7b7d9b1L;
+    return ((int) tmp) ^ ((int) (tmp >>> 32));
   }
 
   @Override
   public boolean equals(final Object obj) {
-    return (obj instanceof NodeDb) && id() == ((NodeDb) obj).id();
+    return (this == obj) || ( (obj instanceof Node) && id() == ((Node) obj).id() );
   }
 }

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -143,13 +143,13 @@ public abstract class NodeRef<N extends NodeDb> implements Node {
     * The style (shift-xor 33 and multiply) is similar to murmur3; the multiply constant is randomly chosen odd number.
     * Feel free to change this.
     * */
-    long tmp = (id() ^ (id() >>> 33)) * 0x1ca213a8d7b7d9b1L;
+    long tmp = (id ^ (id >>> 33)) * 0x1ca213a8d7b7d9b1L;
     return ((int) tmp) ^ ((int) (tmp >>> 32));
   }
 
   @Override
   public boolean equals(final Object obj) {
-    return (this == obj) || ( (obj instanceof Node) && id() == ((Node) obj).id() );
+    return (this == obj) || ( (obj instanceof NodeRef) && id == ((NodeRef) obj).id );
   }
 
   @Override

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -138,7 +138,8 @@ public abstract class NodeRef<N extends NodeDb> implements Node {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id());
+    long tmp = (id ^ (id >>> 33)) * 0x1ca213a8d7b7d9b1L;
+    return ((int) tmp) ^ ((int) (tmp >>> 32));
   }
 
   @Override

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -138,13 +138,18 @@ public abstract class NodeRef<N extends NodeDb> implements Node {
 
   @Override
   public int hashCode() {
-    long tmp = (id ^ (id >>> 33)) * 0x1ca213a8d7b7d9b1L;
+    /* NodeRef compares by id. We need the hash computation to be fast and allocation-free; but we don't need it
+    * very strong. Plain java would use id ^ (id>>>32) ; we do a little bit of mixing.
+    * The style (shift-xor 33 and multiply) is similar to murmur3; the multiply constant is randomly chosen odd number.
+    * Feel free to change this.
+    * */
+    long tmp = (id() ^ (id() >>> 33)) * 0x1ca213a8d7b7d9b1L;
     return ((int) tmp) ^ ((int) (tmp >>> 32));
   }
 
   @Override
   public boolean equals(final Object obj) {
-    return (obj instanceof Node) && id() == ((Node) obj).id();
+    return (this == obj) || ( (obj instanceof Node) && id() == ((Node) obj).id() );
   }
 
   @Override


### PR DESCRIPTION
Found this when reading profiling data. This gives about 5% speedup on dataflow-heavy loads.