### PR TITLE
optional conversion of property values prior to serialization

### DIFF
--- a/core/src/main/java/overflowdb/NodeDb.java
+++ b/core/src/main/java/overflowdb/NodeDb.java
@@ -127,10 +127,12 @@ public abstract class NodeDb extends Node {
     return results;
   }
 
-  /** all properties *but* the default values, to ensure we don't serialize those
-   * Providing a default implementation here, but it'll make sense to override this for efficiency.
+  /** All properties *but* the default values, to ensure we don't serialize those.
+   * Providing a default implementation here, but the codegen overrides this for efficiency.
+   * Properties may have different runtime types here than what they have in `properties()`, e.g. if the domain
+   * classes use primitive arrays for efficiency.
    *  */
-  public Map<String, Object> propertiesMapWithoutDefaults() {
+  public Map<String, Object> propertiesMapForStorage() {
     final Map<String, Object> results = new HashMap<>(propertyKeys().size());
 
     for (String propertyKey : propertyKeys()) {

--- a/core/src/main/java/overflowdb/storage/NodeDeserializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeDeserializer.java
@@ -123,15 +123,13 @@ public class NodeDeserializer extends BookKeeper {
       case DOUBLE:
         return value.asFloatValue().toDouble();
       case LIST:
-        final ArrayValue arrayValue = value.asArrayValue();
-        List deserializedList = new ArrayList(arrayValue.size());
-        final Iterator<Value> valueIterator = arrayValue.iterator();
-        while (valueIterator.hasNext()) {
-          deserializedList.add(unpackValue(valueIterator.next().asArrayValue()));
-        }
-        return deserializedList;
+        return deserializeList(value.asArrayValue());
       case CHARACTER:
         return (char) value.asIntegerValue().asInt();
+      case ARRAY_BYTE:
+        return deserializeArrayByte(value.asArrayValue());
+      case ARRAY_OBJECT:
+        return deserializeArrayObject(value.asArrayValue());
       default:
         throw new UnsupportedOperationException("unknown valueTypeId=`" + valueTypeId);
     }
@@ -148,4 +146,33 @@ public class NodeDeserializer extends BookKeeper {
     return nodeFactoryByLabel.get(label);
   }
 
+  /** only keeping for legacy reasons, going forward, all lists are stored as arrays */
+  private Object deserializeList(ArrayValue arrayValue) {
+    final List deserializedList = new ArrayList(arrayValue.size());
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedList.add(unpackValue(valueIterator.next().asArrayValue()));
+    }
+    return deserializedList;
+  }
+
+  private byte[] deserializeArrayByte(ArrayValue arrayValue) {
+    byte[] deserializedArray = new byte[arrayValue.size()];
+    int idx = 0;
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedArray[idx++] = valueIterator.next().asIntegerValue().asByte();
+    }
+    return deserializedArray;
+  }
+
+  private Object[] deserializeArrayObject(ArrayValue arrayValue) {
+    Object[] deserializedArray = new Object[arrayValue.size()];
+    int idx = 0;
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedArray[idx++] = unpackValue(valueIterator.next().asArrayValue());
+    }
+    return deserializedArray;
+  }
 }

--- a/core/src/main/java/overflowdb/storage/NodeDeserializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeDeserializer.java
@@ -124,12 +124,12 @@ public class NodeDeserializer extends BookKeeper {
         return value.asFloatValue().toDouble();
       case LIST:
         final ArrayValue arrayValue = value.asArrayValue();
-        List deserializedArray = new ArrayList(arrayValue.size());
+        List deserializedList = new ArrayList(arrayValue.size());
         final Iterator<Value> valueIterator = arrayValue.iterator();
         while (valueIterator.hasNext()) {
-          deserializedArray.add(unpackValue(valueIterator.next().asArrayValue()));
+          deserializedList.add(unpackValue(valueIterator.next().asArrayValue()));
         }
-        return deserializedArray;
+        return deserializedList;
       case CHARACTER:
         return (char) value.asIntegerValue().asInt();
       default:

--- a/core/src/main/java/overflowdb/storage/NodeDeserializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeDeserializer.java
@@ -3,6 +3,8 @@ package overflowdb.storage;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessageUnpacker;
 import org.msgpack.value.ArrayValue;
+import org.msgpack.value.ImmutableArrayValue;
+import org.msgpack.value.ImmutableValue;
 import org.msgpack.value.Value;
 import overflowdb.Direction;
 import overflowdb.Graph;
@@ -88,7 +90,8 @@ public class NodeDeserializer extends BookKeeper {
     for (int propertyIdx = 0; propertyIdx < propertyCount; propertyIdx++) {
       int keyId = unpacker.unpackInt();
       final String key = storage.reverseLookupStringToIntMapping(keyId);
-      final Object unpackedProperty = unpackValue(unpacker.unpackValue().asArrayValue());
+      final ImmutableValue unpackedValue = unpacker.unpackValue();
+      final Object unpackedProperty = unpackValue(unpackedValue.asArrayValue());
       res[resIdx++] = key;
       res[resIdx++] = unpackedProperty;
     }
@@ -97,7 +100,7 @@ public class NodeDeserializer extends BookKeeper {
 
   private final Object unpackValue(final ArrayValue packedValueAndType) {
     final Iterator<Value> iter = packedValueAndType.iterator();
-    final byte valueTypeId = iter.next().asIntegerValue().asByte();
+   final byte valueTypeId = iter.next().asIntegerValue().asByte();
     final Value value = iter.next();
 
     switch (ValueTypes.lookup(valueTypeId)) {
@@ -128,6 +131,20 @@ public class NodeDeserializer extends BookKeeper {
         return (char) value.asIntegerValue().asInt();
       case ARRAY_BYTE:
         return deserializeArrayByte(value.asArrayValue());
+      case ARRAY_SHORT:
+        return deserializeArrayShort(value.asArrayValue());
+      case ARRAY_INT:
+        return deserializeArrayInt(value.asArrayValue());
+      case ARRAY_LONG:
+        return deserializeArrayLong(value.asArrayValue());
+      case ARRAY_FLOAT:
+        return deserializeArrayFloat(value.asArrayValue());
+      case ARRAY_DOUBLE:
+        return deserializeArrayDouble(value.asArrayValue());
+      case ARRAY_CHAR:
+        return deserializeArrayChar(value.asArrayValue());
+      case ARRAY_BOOL:
+        return deserializeArrayBoolean(value.asArrayValue());
       case ARRAY_OBJECT:
         return deserializeArrayObject(value.asArrayValue());
       default:
@@ -162,6 +179,76 @@ public class NodeDeserializer extends BookKeeper {
     final Iterator<Value> valueIterator = arrayValue.iterator();
     while (valueIterator.hasNext()) {
       deserializedArray[idx++] = valueIterator.next().asIntegerValue().asByte();
+    }
+    return deserializedArray;
+  }
+
+  private short[] deserializeArrayShort(ArrayValue arrayValue) {
+    short[] deserializedArray = new short[arrayValue.size()];
+    int idx = 0;
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedArray[idx++] = valueIterator.next().asIntegerValue().asShort();
+    }
+    return deserializedArray;
+  }
+
+  private int[] deserializeArrayInt(ArrayValue arrayValue) {
+    int[] deserializedArray = new int[arrayValue.size()];
+    int idx = 0;
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedArray[idx++] = valueIterator.next().asIntegerValue().asInt();
+    }
+    return deserializedArray;
+  }
+
+  private long[] deserializeArrayLong(ArrayValue arrayValue) {
+    long[] deserializedArray = new long[arrayValue.size()];
+    int idx = 0;
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedArray[idx++] = valueIterator.next().asIntegerValue().asLong();
+    }
+    return deserializedArray;
+  }
+
+  private float[] deserializeArrayFloat(ArrayValue arrayValue) {
+    float[] deserializedArray = new float[arrayValue.size()];
+    int idx = 0;
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedArray[idx++] = valueIterator.next().asFloatValue().toFloat();
+    }
+    return deserializedArray;
+  }
+
+  private double[] deserializeArrayDouble(ArrayValue arrayValue) {
+    double[] deserializedArray = new double[arrayValue.size()];
+    int idx = 0;
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedArray[idx++] = valueIterator.next().asFloatValue().toDouble();
+    }
+    return deserializedArray;
+  }
+
+  private char[] deserializeArrayChar(ArrayValue arrayValue) {
+    char[] deserializedArray = new char[arrayValue.size()];
+    int idx = 0;
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedArray[idx++] = (char) valueIterator.next().asIntegerValue().asInt();
+    }
+    return deserializedArray;
+  }
+
+  private boolean[] deserializeArrayBoolean(ArrayValue arrayValue) {
+    boolean[] deserializedArray = new boolean[arrayValue.size()];
+    int idx = 0;
+    final Iterator<Value> valueIterator = arrayValue.iterator();
+    while (valueIterator.hasNext()) {
+      deserializedArray[idx++] = valueIterator.next().asBooleanValue().getBoolean();
     }
     return deserializedArray;
   }

--- a/core/src/main/java/overflowdb/storage/NodeSerializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeSerializer.java
@@ -185,14 +185,13 @@ public class NodeSerializer extends BookKeeper {
       while (listIter.hasNext()) {
         packTypedValue(packer, listIter.next());
       }
-    } else if (value instanceof String[]) {
-      packer.packByte(ValueTypes.LIST.id);
-      String[] array = (String[]) value;
+    } else if (value instanceof Object[]) {
+      packer.packByte(ValueTypes.ARRAY_OBJECT.id);
+      Object[] array = (Object[]) value;
       packer.packArrayHeader(array.length);
-      for (String s : array) { packTypedValue(packer, s); }
+      for (Object s : array) packTypedValue(packer, s);
     } else {
       throw new UnsupportedOperationException("id type `" + value.getClass());
     }
   }
-
 }

--- a/core/src/main/java/overflowdb/storage/NodeSerializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeSerializer.java
@@ -41,7 +41,7 @@ public class NodeSerializer extends BookKeeper {
       final int labelId = storage.lookupOrCreateStringToIntMapping(layoutInformation.label);
       packer.packInt(labelId);
 
-      packProperties(packer, node.propertiesMapWithoutDefaults());
+      packProperties(packer, node.propertiesMapForStorage());
       packEdges(packer, node);
 
       if (statsEnabled) recordStatistics(startTimeNanos);

--- a/core/src/main/java/overflowdb/storage/NodeSerializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeSerializer.java
@@ -10,7 +10,6 @@ import org.msgpack.core.MessagePack;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -178,18 +177,55 @@ public class NodeSerializer extends BookKeeper {
       packer.packByte(ValueTypes.CHARACTER.id);
       packer.packInt((Character) value);
     } else if (value instanceof List) {
-      packer.packByte(ValueTypes.LIST.id);
-      List listValue = (List) value;
-      packer.packArrayHeader(listValue.size());
-      final Iterator listIter = listValue.iterator();
-      while (listIter.hasNext()) {
-        packTypedValue(packer, listIter.next());
-      }
+      packer.packByte(ValueTypes.ARRAY_OBJECT.id);
+      List list = (List) value;
+      packer.packArrayHeader(list.size());
+      for (Object o : list) packTypedValue(packer, o);
     } else if (value instanceof Object[]) {
       packer.packByte(ValueTypes.ARRAY_OBJECT.id);
       Object[] array = (Object[]) value;
       packer.packArrayHeader(array.length);
-      for (Object s : array) packTypedValue(packer, s);
+      for (Object o : array) packTypedValue(packer, o);
+    } else if (value instanceof byte[]) {
+      packer.packByte(ValueTypes.ARRAY_BYTE.id);
+      byte[] array = (byte[]) value;
+      packer.packArrayHeader(array.length);
+      for (byte b : array) packer.packByte(b);
+    } else if (value instanceof short[]) {
+      packer.packByte(ValueTypes.ARRAY_SHORT.id);
+      short[] array = (short[]) value;
+      packer.packArrayHeader(array.length);
+      for (short s : array) packer.packShort(s);
+    } else if (value instanceof int[]) {
+      packer.packByte(ValueTypes.ARRAY_INT.id);
+      int[] array = (int[]) value;
+      packer.packArrayHeader(array.length);
+      for (int i : array) packer.packInt(i);
+    } else if (value instanceof long[]) {
+      packer.packByte(ValueTypes.ARRAY_LONG.id);
+      long[] array = (long[]) value;
+      packer.packArrayHeader(array.length);
+      for (long l : array) packer.packLong(l);
+    } else if (value instanceof float[]) {
+      packer.packByte(ValueTypes.ARRAY_FLOAT.id);
+      float[] array = (float[]) value;
+      packer.packArrayHeader(array.length);
+      for (float f : array) packer.packFloat(f);
+    } else if (value instanceof double[]) {
+      packer.packByte(ValueTypes.ARRAY_DOUBLE.id);
+      double[] array = (double[]) value;
+      packer.packArrayHeader(array.length);
+      for (double d : array) packer.packDouble(d);
+    } else if (value instanceof char[]) {
+      packer.packByte(ValueTypes.ARRAY_CHAR.id);
+      char[] array = (char[]) value;
+      packer.packArrayHeader(array.length);
+      for (char c : array) packer.packInt(c);
+    } else if (value instanceof boolean[]) {
+      packer.packByte(ValueTypes.ARRAY_BOOL.id);
+      boolean[] array = (boolean[]) value;
+      packer.packArrayHeader(array.length);
+      for (boolean b : array) packer.packBoolean(b);
     } else {
       throw new UnsupportedOperationException("id type `" + value.getClass());
     }

--- a/core/src/main/java/overflowdb/storage/NodeSerializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeSerializer.java
@@ -174,6 +174,9 @@ public class NodeSerializer extends BookKeeper {
     } else if (value instanceof Double) {
       packer.packByte(ValueTypes.DOUBLE.id);
       packer.packDouble((double) value);
+    } else if (value instanceof Character) {
+      packer.packByte(ValueTypes.CHARACTER.id);
+      packer.packInt((Character) value);
     } else if (value instanceof List) {
       packer.packByte(ValueTypes.LIST.id);
       List listValue = (List) value;
@@ -182,9 +185,11 @@ public class NodeSerializer extends BookKeeper {
       while (listIter.hasNext()) {
         packTypedValue(packer, listIter.next());
       }
-    } else if (value instanceof Character) {
-      packer.packByte(ValueTypes.CHARACTER.id);
-      packer.packInt((Character) value);
+    } else if (value instanceof String[]) {
+      packer.packByte(ValueTypes.LIST.id);
+      String[] array = (String[]) value;
+      packer.packArrayHeader(array.length);
+      for (String s : array) { packTypedValue(packer, s); }
     } else {
       throw new UnsupportedOperationException("id type `" + value.getClass());
     }

--- a/core/src/main/java/overflowdb/storage/ValueTypes.java
+++ b/core/src/main/java/overflowdb/storage/ValueTypes.java
@@ -13,10 +13,19 @@ public enum ValueTypes {
   LONG((byte) 5),
   FLOAT((byte) 6),
   DOUBLE((byte) 7),
-  LIST((byte) 8),
+  LIST((byte) 8), // only keeping for legacy reasons, going forward, all lists are stored as arrays
   NODE_REF((byte) 9),
   UNKNOWN((byte) 10),
-  CHARACTER((byte) 11);
+  CHARACTER((byte) 11),
+  ARRAY_BYTE((byte) 12),
+  ARRAY_SHORT((byte) 13),
+  ARRAY_INT((byte) 14),
+  ARRAY_LONG((byte) 15),
+  ARRAY_FLOAT((byte) 16),
+  ARRAY_DOUBLE((byte) 17),
+  ARRAY_CHAR((byte) 18),
+  ARRAY_BOOL((byte) 19),
+  ARRAY_OBJECT((byte) 20);
 
   public final byte id;
 
@@ -26,30 +35,27 @@ public enum ValueTypes {
 
   public static ValueTypes lookup(byte id) {
     switch (id) {
-      case 0:
-        return BOOLEAN;
-      case 1:
-        return STRING;
-      case 2:
-        return BYTE;
-      case 3:
-        return SHORT;
-      case 4:
-        return INTEGER;
-      case 5:
-        return LONG;
-      case 6:
-        return FLOAT;
-      case 7:
-        return DOUBLE;
-      case 8:
-        return LIST;
-      case 9:
-        return NODE_REF;
-      case 10:
-        return UNKNOWN;
-      case 11:
-        return CHARACTER;
+      case 0: return BOOLEAN;
+      case 1: return STRING;
+      case 2: return BYTE;
+      case 3: return SHORT;
+      case 4: return INTEGER;
+      case 5: return LONG;
+      case 6: return FLOAT;
+      case 7: return DOUBLE;
+      case 8: return LIST;
+      case 9: return NODE_REF;
+      case 10: return UNKNOWN;
+      case 11: return CHARACTER;
+      case 12: return ARRAY_BYTE;
+      case 13: return ARRAY_SHORT;
+      case 14: return ARRAY_INT;
+      case 15: return ARRAY_LONG;
+      case 16: return ARRAY_FLOAT;
+      case 17: return ARRAY_DOUBLE;
+      case 18: return ARRAY_CHAR;
+      case 19: return ARRAY_BOOL;
+      case 20: return ARRAY_OBJECT;
       default:
         throw new IllegalArgumentException("unknown id type " + id);
     }

--- a/core/src/test/java/overflowdb/storage/SerializerTest.java
+++ b/core/src/test/java/overflowdb/storage/SerializerTest.java
@@ -16,11 +16,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class SerializerTest {
 
@@ -39,11 +40,22 @@ public class SerializerTest {
 
       TestNodeDb testNodeDb = testNode.get();
       byte[] bytes = serializer.serialize(testNodeDb);
-      Node deserialized = deserializer.deserialize(bytes);
+      TestNodeDb deserialized = (TestNodeDb) deserializer.deserialize(bytes);
 
       assertEquals(testNodeDb.id(), deserialized.id());
       assertEquals(testNodeDb.label(), deserialized.label());
-      assertEquals(testNodeDb.propertiesMap(), deserialized.propertiesMap());
+      assertEquals(testNodeDb.stringProperty(), deserialized.stringProperty());
+      assertEquals(testNodeDb.intProperty(), deserialized.intProperty());
+      assertEquals(testNodeDb.stringListProperty(), deserialized.stringListProperty());
+      assertEquals(testNodeDb.intListProperty(), deserialized.intListProperty());
+
+      final Map<String, Object> propertiesMap = testNodeDb.propertiesMap();
+      final Map<String, Object> propertiesMapDeserialized = deserialized.propertiesMap();
+      assertEquals(propertiesMap.get(TestNode.STRING_PROPERTY), propertiesMapDeserialized.get(TestNode.STRING_PROPERTY));
+      assertEquals(propertiesMap.get(TestNode.INT_PROPERTY), propertiesMapDeserialized.get(TestNode.INT_PROPERTY));
+      assertEquals(propertiesMap.get(TestNode.STRING_LIST_PROPERTY), propertiesMapDeserialized.get(TestNode.STRING_LIST_PROPERTY));
+      assertArrayEquals((int[]) propertiesMap.get(TestNode.INT_LIST_PROPERTY),
+                        (int[]) propertiesMapDeserialized.get(TestNode.INT_LIST_PROPERTY));
 
       final NodeRef deserializedRef = deserializer.deserializeRef(bytes);
       assertEquals(testNode.id(), deserializedRef.id());

--- a/core/src/test/java/overflowdb/storage/SerializerTest.java
+++ b/core/src/test/java/overflowdb/storage/SerializerTest.java
@@ -2,11 +2,7 @@ package overflowdb.storage;
 
 import org.junit.Test;
 import overflowdb.Config;
-import overflowdb.EdgeFactory;
 import overflowdb.Node;
-import overflowdb.NodeDb;
-import overflowdb.NodeFactory;
-import overflowdb.NodeLayoutInformation;
 import overflowdb.NodeRef;
 import overflowdb.Edge;
 import overflowdb.Graph;
@@ -19,8 +15,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/core/src/test/java/overflowdb/storage/SerializerTest.java
+++ b/core/src/test/java/overflowdb/storage/SerializerTest.java
@@ -72,7 +72,7 @@ public class SerializerTest {
       assertEquals(testNodeDb.id(), deserialized.id());
       assertEquals(testNodeDb.propertiesMap(), deserialized.propertiesMap());
       TestNodeDb deserializedTestNode = (TestNodeDb) deserialized;
-      assertEquals(deserializedTestNode.funkyList().getEntries(), Arrays.asList("foo"));
+      assertEquals(deserializedTestNode.funkyList().getEntries(), Arrays.asList("anthropomorphic", "boondoggle"));
     }
   }
 

--- a/core/src/test/java/overflowdb/storage/SerializerTest.java
+++ b/core/src/test/java/overflowdb/storage/SerializerTest.java
@@ -142,7 +142,7 @@ public class SerializerTest {
     assertEquals("DEFAULT_STRING_VALUE", testNode1.stringProperty());
     assertEquals("DEFAULT_STRING_VALUE", testNode1.property(stringPropertyKey));
     assertEquals("DEFAULT_STRING_VALUE", testNode1.propertiesMap().get(stringPropertyKey));
-    assertFalse(testNode1.get().propertiesMapWithoutDefaults().containsKey(stringPropertyKey));
+    assertFalse(testNode1.get().propertiesMapForStorage().containsKey(stringPropertyKey));
     assertEquals(new Long(-99l), testEdge.longProperty());
     assertEquals(new Long(-99l), testEdge.property(longPropertyKey));
     assertEquals(new Long(-99l), testEdge.propertiesMap().get(longPropertyKey));
@@ -161,7 +161,7 @@ public class SerializerTest {
     assertEquals("NEW_DEFAULT_STRING_VALUE", n1Deserialized.stringProperty());
     assertEquals("NEW_DEFAULT_STRING_VALUE", n1Deserialized.property(stringPropertyKey));
     assertEquals("NEW_DEFAULT_STRING_VALUE", n1Deserialized.propertiesMap().get(stringPropertyKey));
-    assertFalse(n1Deserialized.get().propertiesMapWithoutDefaults().containsKey(stringPropertyKey));
+    assertFalse(n1Deserialized.get().propertiesMapForStorage().containsKey(stringPropertyKey));
     assertEquals(new Long(-49l), edge1Deserialized.longProperty());
     assertEquals(new Long(-49l), edge1Deserialized.property(longPropertyKey));
     assertEquals(new Long(-49l), edge1Deserialized.propertiesMap().get(longPropertyKey));

--- a/core/src/test/java/overflowdb/testdomains/simple/FunkyList.java
+++ b/core/src/test/java/overflowdb/testdomains/simple/FunkyList.java
@@ -3,6 +3,7 @@ package overflowdb.testdomains.simple;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -28,6 +29,19 @@ public class FunkyList {
 
   public List<String> getEntries() {
     return new ArrayList<>(entries);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FunkyList funkyList = (FunkyList) o;
+    return entries.equals(funkyList.entries);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entries);
   }
 
   public static Function<FunkyList, String[]> toStorageType =

--- a/core/src/test/java/overflowdb/testdomains/simple/FunkyList.java
+++ b/core/src/test/java/overflowdb/testdomains/simple/FunkyList.java
@@ -1,0 +1,36 @@
+package overflowdb.testdomains.simple;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/** a funky list that supports only funky entries.. to test `NodeSerializer.convertPropertyForPersistence` */
+public class FunkyList {
+  private List<String> entries = new ArrayList();
+
+  private static Set<String> funkyWords = new HashSet<String>() {{
+    add("anthropomorphic");
+    add("apoplectic");
+    add("appaloosa");
+    add("bedlam");
+    add("boondoggle");
+    add("bucolic");
+  }};
+
+  public FunkyList add(String value) {
+    if (funkyWords.contains(value)) {
+      entries.add(value);
+      return this;
+    } else throw new RuntimeException("not funky enough!");
+  }
+
+  public List<String> getEntries() {
+    return new ArrayList<>(entries);
+  }
+
+  public static Function<FunkyList, String[]> toStorageType =
+      funkyList -> funkyList.entries.toArray(new String[funkyList.entries.size()]);
+
+}

--- a/core/src/test/java/overflowdb/testdomains/simple/TestNode.java
+++ b/core/src/test/java/overflowdb/testdomains/simple/TestNode.java
@@ -13,6 +13,7 @@ public class TestNode extends NodeRef<TestNodeDb> {
   public static final String INT_PROPERTY = "IntProperty";
   public static final String STRING_LIST_PROPERTY = "StringListProperty";
   public static final String INT_LIST_PROPERTY = "IntListProperty";
+  public static final String FUNKY_LIST_PROPERTY = "FunkyListProperty";
 
   public TestNode(Graph graph, long id) {
     super(graph, id);
@@ -38,6 +39,8 @@ public class TestNode extends NodeRef<TestNodeDb> {
   public List<Integer> intListProperty() {
     return get().intListProperty();
   }
+
+  public FunkyList funkyList() { return get().funkyList(); }
 
   @Override
   public Object propertyDefaultValue(String propertyKey) {

--- a/core/src/test/java/overflowdb/testdomains/simple/TestNodeDb.java
+++ b/core/src/test/java/overflowdb/testdomains/simple/TestNodeDb.java
@@ -89,11 +89,11 @@ public class TestNodeDb extends NodeDb {
         this._intListProperty.add((Integer) value);
       }
     } else if (TestNode.FUNKY_LIST_PROPERTY.equals(key)) {
-      if (value instanceof String[]) {
-        String[] valueAsStrings = (String[]) value;
+      if (value instanceof Object[]) {
+        Object[] values = (Object[]) value;
         this._funkyList = new FunkyList();
-        for (String entry : valueAsStrings) {
-          _funkyList.add(entry);
+        for (Object entry : values) {
+          _funkyList.add((String) entry);
         }
       } else {
         this._funkyList = (FunkyList) value;

--- a/core/src/test/java/overflowdb/testdomains/simple/TestNodeDb.java
+++ b/core/src/test/java/overflowdb/testdomains/simple/TestNodeDb.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class TestNodeDb extends NodeDb {
   protected TestNodeDb(NodeRef ref) {
@@ -19,7 +20,7 @@ public class TestNodeDb extends NodeDb {
   private String _stringProperty;
   private Integer _intProperty;
   private List<String> _stringListProperty;
-  private List<Integer> _intListProperty;
+  private int[] _intListProperty; // to test primitive arrays serialization
   private FunkyList _funkyList;
 
   public String stringProperty() {
@@ -38,7 +39,7 @@ public class TestNodeDb extends NodeDb {
   }
 
   public List<Integer> intListProperty() {
-    return _intListProperty;
+    return Arrays.stream(_intListProperty).boxed().collect(Collectors.toList());
   }
 
   public FunkyList funkyList() {
@@ -60,7 +61,7 @@ public class TestNodeDb extends NodeDb {
     } else if (key == TestNode.INT_PROPERTY) {
       return intProperty();
     } else if (key == TestNode.INT_LIST_PROPERTY) {
-      return intListProperty();
+      return _intListProperty;
     } else if (key == TestNode.FUNKY_LIST_PROPERTY) {
       return funkyList();
     } else {
@@ -75,6 +76,8 @@ public class TestNodeDb extends NodeDb {
     } else if (TestNode.STRING_LIST_PROPERTY.equals(key)) {
       if (value instanceof List) {
         this._stringListProperty = (List) value;
+      } else if (value instanceof Object[]) {
+        this._stringListProperty = Arrays.stream((Object[]) value).map(s -> (String) s).collect(Collectors.toList());
       } else {
         if (this._stringListProperty == null) this._stringListProperty = new ArrayList<>();
         this._stringListProperty.add((String) value);
@@ -83,10 +86,14 @@ public class TestNodeDb extends NodeDb {
       this._intProperty = (Integer) value;
     } else if (TestNode.INT_LIST_PROPERTY.equals(key)) {
       if (value instanceof List) {
-        this._intListProperty = (List) value;
+        List valueAsList = (List) value;
+        this._intListProperty = new int[valueAsList.size()];
+        int idx = 0;
+        for (Integer i : _intListProperty) _intListProperty[idx++] = i;
+      } else if (value instanceof int[]) {
+        this._intListProperty = (int[]) value;
       } else {
-        if (this._intListProperty == null) this._intListProperty = new ArrayList<>();
-        this._intListProperty.add((Integer) value);
+        throw new RuntimeException("not implemented... " + value.getClass());
       }
     } else if (TestNode.FUNKY_LIST_PROPERTY.equals(key)) {
       if (value instanceof Object[]) {

--- a/core/src/test/java/overflowdb/testdomains/simple/TestNodeDb.java
+++ b/core/src/test/java/overflowdb/testdomains/simple/TestNodeDb.java
@@ -20,6 +20,7 @@ public class TestNodeDb extends NodeDb {
   private Integer _intProperty;
   private List<String> _stringListProperty;
   private List<Integer> _intListProperty;
+  private FunkyList _funkyList;
 
   public String stringProperty() {
     if (_stringProperty != null)
@@ -40,6 +41,10 @@ public class TestNodeDb extends NodeDb {
     return _intListProperty;
   }
 
+  public FunkyList funkyList() {
+    return _funkyList;
+  }
+
   @Override
   public NodeLayoutInformation layoutInformation() {
     return layoutInformation;
@@ -56,6 +61,8 @@ public class TestNodeDb extends NodeDb {
       return intProperty();
     } else if (key == TestNode.INT_LIST_PROPERTY) {
       return intListProperty();
+    } else if (key == TestNode.FUNKY_LIST_PROPERTY) {
+      return funkyList();
     } else {
       return propertyDefaultValue(key);
     }
@@ -81,6 +88,16 @@ public class TestNodeDb extends NodeDb {
         if (this._intListProperty == null) this._intListProperty = new ArrayList<>();
         this._intListProperty.add((Integer) value);
       }
+    } else if (TestNode.FUNKY_LIST_PROPERTY.equals(key)) {
+      if (value instanceof String[]) {
+        String[] valueAsStrings = (String[]) value;
+        this._funkyList = new FunkyList();
+        for (String entry : valueAsStrings) {
+          _funkyList.add(entry);
+        }
+      } else {
+        this._funkyList = (FunkyList) value;
+      }
     } else {
       throw new RuntimeException("property with key=" + key + " not (yet) supported by " + this.getClass().getName());
     }
@@ -96,6 +113,8 @@ public class TestNodeDb extends NodeDb {
       this._intProperty = null;
     } else if (TestNode.INT_LIST_PROPERTY.equals(key)) {
       this._intListProperty = null;
+    } else if (TestNode.FUNKY_LIST_PROPERTY.equals(key)) {
+      this._funkyList = null;
     } else {
       throw new RuntimeException("property with key=" + key + " not (yet) supported by " + this.getClass().getName());
     }
@@ -103,7 +122,8 @@ public class TestNodeDb extends NodeDb {
 
   public static NodeLayoutInformation layoutInformation = new NodeLayoutInformation(
       TestNode.LABEL,
-      new HashSet<>(Arrays.asList(TestNode.STRING_PROPERTY, TestNode.INT_PROPERTY, TestNode.STRING_LIST_PROPERTY, TestNode.INT_LIST_PROPERTY)),
+      new HashSet<>(Arrays.asList(TestNode.STRING_PROPERTY, TestNode.INT_PROPERTY, TestNode.STRING_LIST_PROPERTY, TestNode.INT_LIST_PROPERTY, TestNode.FUNKY_LIST_PROPERTY)),
       Arrays.asList(TestEdge.layoutInformation),
       Arrays.asList(TestEdge.layoutInformation));
+
 }


### PR DESCRIPTION
* supersedes https://github.com/ShiftLeftSecurity/overflowdb/pull/204 with a nicer design: rather than providing the conversion for node and edge properties on NodeDb, we can now register a function when opening the graph - the conversion is always the same anyway
* also: support for primitive arrays without boxing

related: https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/91