### PR TITLE
fix race conditions between writes and reads of adjacent nodes/edges/edgeProperties

### DIFF
--- a/core/src/main/java/overflowdb/AdjacentNodes.java
+++ b/core/src/main/java/overflowdb/AdjacentNodes.java
@@ -1,0 +1,29 @@
+package overflowdb;
+
+import overflowdb.util.PackedIntArray;
+
+public class AdjacentNodes {
+
+  /**
+   * holds refs to all adjacent nodes (a.k.a. dummy edges) and the edge properties
+   */
+  public final Object[] nodesWithEdgeProperties;
+
+  /* store the start offset and length into the above `adjacentNodesWithEdgeProperties` array in an interleaved manner,
+   * i.e. each adjacent edge type has two entries in this array. */
+  public final PackedIntArray edgeOffsets;
+
+  /**
+   * create an empty AdjacentNodes container for a node with @param numberOfDifferentAdjacentTypes
+   */
+  public AdjacentNodes(int numberOfDifferentAdjacentTypes) {
+    nodesWithEdgeProperties = new Object[0];
+    edgeOffsets = PackedIntArray.create(numberOfDifferentAdjacentTypes * 2);
+  }
+
+  public AdjacentNodes(Object[] nodesWithEdgeProperties, PackedIntArray edgeOffsets) {
+    this.nodesWithEdgeProperties = nodesWithEdgeProperties;
+    this.edgeOffsets = edgeOffsets;
+  }
+
+}

--- a/core/src/main/java/overflowdb/NodeDb.java
+++ b/core/src/main/java/overflowdb/NodeDb.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -30,18 +29,11 @@ public abstract class NodeDb extends Node {
   public final NodeRef ref;
 
   /**
-   * holds refs to all adjacent nodes (a.k.a. dummy edges) and the edge properties
+   * Using separate volatile container for the large array (adjacentNodesWithEdgeProperties) and the small
+   * array (edgeOffsets) to prevent jit/cpu reordering, potentially leading to race conditions when edges are
+   * added/removed and traversed by other threads in parallel.
    */
-  private Object[] adjacentNodesWithEdgeProperties = new Object[0];
-
-  /* store the start offset and length into the above `adjacentNodesWithEdgeProperties` array in an interleaved manner,
-   * i.e. each adjacent edge type has two entries in this array. */
-  private PackedIntArray edgeOffsets;
-
-  @Override
-  public Object propertyDefaultValue(String propertyKey) {
-    return ref.propertyDefaultValue(propertyKey);
-  }
+  private volatile AdjacentNodes adjacentNodes;
 
   /**
    * Flag that helps us save time when serializing, both when overflowing to disk and when storing
@@ -61,29 +53,13 @@ public abstract class NodeDb extends Node {
       ref.graph.referenceManager.applyBackpressureMaybe();
     }
 
-    edgeOffsets = PackedIntArray.create(layoutInformation().numberOfDifferentAdjacentTypes() * 2);
+    adjacentNodes = new AdjacentNodes(layoutInformation().numberOfDifferentAdjacentTypes());
   }
 
   public abstract NodeLayoutInformation layoutInformation();
 
-  public Object[] getAdjacentNodesWithEdgeProperties() {
-    return adjacentNodesWithEdgeProperties;
-  }
-
-  public void setAdjacentNodesWithEdgeProperties(Object[] adjacentNodesWithEdgeProperties) {
-    this.adjacentNodesWithEdgeProperties = adjacentNodesWithEdgeProperties;
-  }
-
-  public int[] getEdgeOffsets() {
-    return edgeOffsets.toIntArray();
-  }
-
-  public PackedIntArray getEdgeOffsetsPackedArray() {
-    return edgeOffsets;
-  }
-
-  public void setEdgeOffsets(int[] edgeOffsets) {
-    this.edgeOffsets = PackedIntArray.of(edgeOffsets);
+  public AdjacentNodes getAdjacentNodes() {
+    return adjacentNodes;
   }
 
   @Override
@@ -146,6 +122,11 @@ public abstract class NodeDb extends Node {
   @Override
   public Set<String> propertyKeys() {
     return layoutInformation().propertyKeys();
+  }
+
+  @Override
+  public Object propertyDefaultValue(String propertyKey) {
+    return ref.propertyDefaultValue(propertyKey);
   }
 
   @Override
@@ -248,11 +229,12 @@ public abstract class NodeDb extends Node {
                             Edge edge,
                             int blockOffset,
                             String key) {
-    int propertyPosition = getEdgePropertyIndex(direction, edge.label(), key, blockOffset);
+    AdjacentNodes adjacentNodes = this.adjacentNodes;
+    int propertyPosition = getEdgePropertyIndex(adjacentNodes, direction, edge.label(), key, blockOffset);
     if (propertyPosition == -1) {
       return null;
     }
-    return (P) adjacentNodesWithEdgeProperties[propertyPosition];
+    return (P) adjacentNodes.nodesWithEdgeProperties[propertyPosition];
   }
 
   public <V> void setEdgeProperty(Direction direction,
@@ -260,26 +242,31 @@ public abstract class NodeDb extends Node {
                                   String key,
                                   V value,
                                   int blockOffset) {
-    int propertyPosition = getEdgePropertyIndex(direction, edgeLabel, key, blockOffset);
+    // TODO fix race with growAdjacentNodesArray, e.g.  synchronize with grow/store adjacentnode
+    AdjacentNodes adjacentNodes = this.adjacentNodes;
+    int propertyPosition = getEdgePropertyIndex(adjacentNodes, direction, edgeLabel, key, blockOffset);
     if (propertyPosition == -1) {
       throw new RuntimeException("Edge " + edgeLabel + " does not support property `" + key + "`.");
     }
-    adjacentNodesWithEdgeProperties[propertyPosition] = value;
+    adjacentNodes.nodesWithEdgeProperties[propertyPosition] = value;
     /* marking as dirty *after* we updated - if node gets serialized before we finish, it'll be marked as dirty */
     this.markAsDirty();
   }
 
   public void removeEdgeProperty(Direction direction, String edgeLabel, String key, int blockOffset) {
-    int propertyPosition = getEdgePropertyIndex(direction, edgeLabel, key, blockOffset);
+    // TODO fix race with growAdjacentNodesArray, e.g.  synchronize with grow/store adjacentnode
+    AdjacentNodes adjacentNodes = this.adjacentNodes;
+    int propertyPosition = getEdgePropertyIndex(adjacentNodes, direction, edgeLabel, key, blockOffset);
     if (propertyPosition == -1) {
       throw new RuntimeException("Edge " + edgeLabel + " does not support property `" + key + "`.");
     }
-    adjacentNodesWithEdgeProperties[propertyPosition] = null;
+    adjacentNodes.nodesWithEdgeProperties[propertyPosition] = null;
     /* marking as dirty *after* we updated - if node gets serialized before we finish, it'll be marked as dirty */
     this.markAsDirty();
   }
 
-  private int calcAdjacentNodeIndex(Direction direction,
+  private int calcAdjacentNodeIndex(AdjacentNodes adjacentNodes,
+                                    Direction direction,
                                     String edgeLabel,
                                     int blockOffset) {
     int offsetPos = getPositionInEdgeOffsets(direction, edgeLabel);
@@ -287,18 +274,19 @@ public abstract class NodeDb extends Node {
       return -1;
     }
 
-    int start = startIndex(offsetPos);
+    int start = startIndex(adjacentNodes, offsetPos);
     return start + blockOffset;
   }
 
   /**
    * Return -1 if there exists no edge property for the provided argument combination.
    */
-  private int getEdgePropertyIndex(Direction direction,
+  private int getEdgePropertyIndex(AdjacentNodes adjacentNodes,
+                                   Direction direction,
                                    String label,
                                    String key,
                                    int blockOffset) {
-    int adjacentNodeIndex = calcAdjacentNodeIndex(direction, label, blockOffset);
+    int adjacentNodeIndex = calcAdjacentNodeIndex(adjacentNodes, direction, label, blockOffset);
     if (adjacentNodeIndex == -1) {
       return -1;
     }
@@ -443,17 +431,18 @@ public abstract class NodeDb extends Node {
 
   protected int outEdgeCount() {
     int count = 0;
+    AdjacentNodes adjacentNodes = this.adjacentNodes;
     for (String label : layoutInformation().allowedOutEdgeLabels()) {
       int offsetPos = getPositionInEdgeOffsets(Direction.OUT, label);
       if (offsetPos != -1) {
-        int start = startIndex(offsetPos);
-        int length = blockLength(offsetPos);
+        int start = startIndex(adjacentNodes, offsetPos);
+        int length = blockLength(adjacentNodes, offsetPos);
         int strideSize = getStrideSize(label);
         int exclusiveEnd = start + length;
         for (int i = start;
-             i < adjacentNodesWithEdgeProperties.length && i < exclusiveEnd;
+             i < adjacentNodes.nodesWithEdgeProperties.length && i < exclusiveEnd;
              i += strideSize) {
-          if (adjacentNodesWithEdgeProperties[i] != null) {
+          if (adjacentNodes.nodesWithEdgeProperties[i] != null) {
             count++;
           }
         }
@@ -471,12 +460,14 @@ public abstract class NodeDb extends Node {
    * adjacent node occurred between the start of the edge-specific block and the blockOffset
    */
   protected final int blockOffsetToOccurrence(Direction direction,
-                                     String label,
-                                     NodeRef otherNode,
-                                     int blockOffset) {
+                                              String label,
+                                              NodeRef otherNode,
+                                              int blockOffset) {
+    AdjacentNodes adjacentNodes = this.adjacentNodes;
     int offsetPos = getPositionInEdgeOffsets(direction, label);
-    int start = startIndex(offsetPos);
+    int start = startIndex(adjacentNodes, offsetPos);
     int strideSize = getStrideSize(label);
+    Object[] adjacentNodesWithEdgeProperties = adjacentNodes.nodesWithEdgeProperties;
 
     int occurrenceCount = -1;
     for (int i = start; i <= start + blockOffset; i += strideSize) {
@@ -502,14 +493,16 @@ public abstract class NodeDb extends Node {
    * @return the index into `adjacentNodesWithEdgeProperties`
    */
   protected final int occurrenceToBlockOffset(Direction direction,
-                                     String label,
-                                     NodeRef adjacentNode,
-                                     int occurrence) {
+                                              String label,
+                                              NodeRef adjacentNode,
+                                              int occurrence) {
+    AdjacentNodes adjacentNodes = this.adjacentNodes;
     int offsetPos = getPositionInEdgeOffsets(direction, label);
-    int start = startIndex(offsetPos);
-    int length = blockLength(offsetPos);
+    int start = startIndex(adjacentNodes, offsetPos);
+    int length = blockLength(adjacentNodes, offsetPos);
     int strideSize = getStrideSize(label);
 
+    Object[] adjacentNodesWithEdgeProperties = adjacentNodes.nodesWithEdgeProperties;
     int currentOccurrence = 0;
     int exclusiveEnd = start + length;
     for (int i = start; i < exclusiveEnd; i += strideSize) {
@@ -537,9 +530,12 @@ public abstract class NodeDb extends Node {
    * @param blockOffset must have been initialized
    */
   protected final synchronized void removeEdge(Direction direction, String label, int blockOffset) {
+    // TODO fix race with growAdjacentNodesArray, e.g.  synchronize with grow/store adjacentnode
+    AdjacentNodes adjacentNodes = this.adjacentNodes;
     int offsetPos = getPositionInEdgeOffsets(direction, label);
-    int start = startIndex(offsetPos) + blockOffset;
+    int start = startIndex(adjacentNodes, offsetPos) + blockOffset;
     int strideSize = getStrideSize(label);
+    Object[] adjacentNodesWithEdgeProperties = adjacentNodes.nodesWithEdgeProperties;
 
     for (int i = start; i < start + strideSize; i++) {
       adjacentNodesWithEdgeProperties[i] = null;
@@ -551,7 +547,7 @@ public abstract class NodeDb extends Node {
 
   private Iterator<Edge> createDummyEdgeIterator(Direction direction, String... labels) {
     if (labels.length == 1) {
-      return createDummyEdgeIteratorForSingleLabel(direction, labels[0]);
+      return createDummyEdgeIteratorForSingleLabel(adjacentNodes, direction, labels[0]);
     } else {
       final String[] labelsToFollow =
           labels.length == 0
@@ -559,21 +555,22 @@ public abstract class NodeDb extends Node {
               : labels;
       final MultiIterator<Edge> multiIterator = new MultiIterator<>();
       for (String label : labelsToFollow) {
-        multiIterator.addIterator(createDummyEdgeIteratorForSingleLabel(direction, label));
+        multiIterator.addIterator(createDummyEdgeIteratorForSingleLabel(adjacentNodes, direction, label));
       }
       return multiIterator;
     }
   }
 
-  private Iterator<Edge> createDummyEdgeIteratorForSingleLabel(Direction direction, String label) {
+  private Iterator<Edge> createDummyEdgeIteratorForSingleLabel(
+      AdjacentNodes adjacentNodes, Direction direction, String label) {
     int offsetPos = getPositionInEdgeOffsets(direction, label);
     if (offsetPos != -1) {
-      int start = startIndex(offsetPos);
-      int length = blockLength(offsetPos);
+      int start = startIndex(adjacentNodes, offsetPos);
+      int length = blockLength(adjacentNodes, offsetPos);
       int strideSize = getStrideSize(label);
 
-      return new DummyEdgeIterator(adjacentNodesWithEdgeProperties, start, start + length, strideSize,
-          direction, label, ref);
+      return new DummyEdgeIterator(
+          adjacentNodes.nodesWithEdgeProperties, start, start + length, strideSize, direction, label, ref);
     } else {
       return Collections.emptyIterator();
     }
@@ -598,11 +595,12 @@ public abstract class NodeDb extends Node {
   /* Simplify hoisting of string lookups.
    * n.b. `final` so that the JIT compiler can inline it */
   public final <A extends Node> Iterator<A> createAdjacentNodeIteratorByOffSet(int offsetPos) {
+    AdjacentNodes adjacentNodes = this.adjacentNodes;
     if (offsetPos != -1) {
-      int start = startIndex(offsetPos);
-      int length = blockLength(offsetPos);
+      int start = startIndex(adjacentNodes, offsetPos);
+      int length = blockLength(adjacentNodes, offsetPos);
       int strideSize = layoutInformation().getEdgePropertyCountByOffsetPos(offsetPos) + 1;
-      return new ArrayOffsetIterator<>(adjacentNodesWithEdgeProperties, start, start + length, strideSize);
+      return new ArrayOffsetIterator<>(adjacentNodes.nodesWithEdgeProperties, start, start + length, strideSize);
     } else {
       return Collections.emptyIterator();
     }
@@ -636,33 +634,37 @@ public abstract class NodeDb extends Node {
   }
 
   private final synchronized int storeAdjacentNode(Direction direction, String edgeLabel, NodeRef nodeRef) {
+    // TODO add writer lock - no more need for synchronized?
     int offsetPos = getPositionInEdgeOffsets(direction, edgeLabel);
     if (offsetPos == -1) {
       throw new RuntimeException("Edge of type " + edgeLabel + " with direction " + direction +
           " not supported by class " + getClass().getSimpleName());
     }
-    int start = startIndex(offsetPos);
-    int length = blockLength(offsetPos);
+    int start = startIndex(adjacentNodes, offsetPos);
+    int length = blockLength(adjacentNodes, offsetPos);
     int strideSize = getStrideSize(edgeLabel);
+
+    Object[] adjacentNodesWithEdgeProperties = adjacentNodes.nodesWithEdgeProperties;
+    int edgeOffsetLengthB2 = adjacentNodes.edgeOffsets.length() >> 1;
 
     int insertAt = start + length;
     if (adjacentNodesWithEdgeProperties.length <= insertAt
             || adjacentNodesWithEdgeProperties[insertAt] != null
-            || (offsetPos + 1 < (edgeOffsets.length()>>1) && insertAt >= startIndex(offsetPos + 1))) {
+            || (offsetPos + 1 < edgeOffsetLengthB2 && insertAt >= startIndex(adjacentNodes, offsetPos + 1))) {
       // space already occupied - grow adjacentNodesWithEdgeProperties array, leaving some room for more elements
-      adjacentNodesWithEdgeProperties = growAdjacentNodesWithEdgeProperties(offsetPos, strideSize, insertAt, length);
+      this.adjacentNodes = growAdjacentNodesWithEdgeProperties(adjacentNodes, offsetPos, strideSize, insertAt, length);
     }
 
-    adjacentNodesWithEdgeProperties[insertAt] = nodeRef;
+    adjacentNodes.nodesWithEdgeProperties[insertAt] = nodeRef;
     // update edgeOffset length to include the newly inserted element
-    edgeOffsets.set(2 * offsetPos + 1, length + strideSize);
+    adjacentNodes.edgeOffsets.set(2 * offsetPos + 1, length + strideSize);
 
     int blockOffset = length;
     return blockOffset;
   }
 
-  public int startIndex(int offsetPosition) {
-    return edgeOffsets.get(2 * offsetPosition);
+  public int startIndex(AdjacentNodes adjacentNodes, int offsetPosition) {
+    return adjacentNodes.edgeOffsets.get(2 * offsetPosition);
   }
 
   /**
@@ -696,8 +698,8 @@ public abstract class NodeDb extends Node {
    * Returns the length of an edge type block in the adjacentNodesWithEdgeProperties array.
    * Length means number of index positions.
    */
-  public final int blockLength(int offsetPosition) {
-    return edgeOffsets.get(2 * offsetPosition + 1);
+  public final int blockLength(AdjacentNodes adjacentNodes, int offsetPosition) {
+    return adjacentNodes.edgeOffsets.get(2 * offsetPosition + 1);
   }
 
   /**
@@ -707,27 +709,22 @@ public abstract class NodeDb extends Node {
    * (tradeoff between performance and memory).
    * grows with the square root of the double of the current capacity.
    */
-  private final synchronized Object[] growAdjacentNodesWithEdgeProperties(int offsetPos,
-                                                   int strideSize,
-                                                   int insertAt,
-                                                   int currentLength) {
-    // TODO optimize growth function - optimizing has potential to save a lot of memory, but the below slowed down processing massively
-//    int currentCapacity = currentLength / strideSize;
-//    double additionalCapacity = Math.sqrt(currentCapacity) + 1;
-//    int additionalCapacityInt = (int) Math.ceil(additionalCapacity);
-//    int additionalEntriesCount = additionalCapacityInt * strideSize;
+  private final synchronized AdjacentNodes growAdjacentNodesWithEdgeProperties(
+      AdjacentNodes adjacentNodesOld, int offsetPos, int strideSize, int insertAt, int currentLength) {
     int growthEmptyFactor = 2;
     int additionalEntriesCount = (currentLength + strideSize) * growthEmptyFactor;
-    int newSize = adjacentNodesWithEdgeProperties.length + additionalEntriesCount;
-    Object[] newArray = new Object[newSize];
-    System.arraycopy(adjacentNodesWithEdgeProperties, 0, newArray, 0, insertAt);
-    System.arraycopy(adjacentNodesWithEdgeProperties, insertAt, newArray, insertAt + additionalEntriesCount, adjacentNodesWithEdgeProperties.length - insertAt);
+    Object[] nodesWithEdgePropertiesOld = adjacentNodesOld.nodesWithEdgeProperties;
+    int newSize = nodesWithEdgePropertiesOld.length + additionalEntriesCount;
+    Object[] nodesWithEdgePropertiesNew = new Object[newSize];
+    System.arraycopy(nodesWithEdgePropertiesOld, 0, nodesWithEdgePropertiesNew, 0, insertAt);
+    System.arraycopy(nodesWithEdgePropertiesOld, insertAt, nodesWithEdgePropertiesNew, insertAt + additionalEntriesCount, nodesWithEdgePropertiesOld.length - insertAt);
 
+    PackedIntArray edgeOffsetsNew = adjacentNodesOld.edgeOffsets.clone();
     // Increment all following start offsets by `additionalEntriesCount`.
-    for (int i = offsetPos + 1; 2 * i < edgeOffsets.length(); i++) {
-      edgeOffsets.set(2 * i, edgeOffsets.get(2 * i) + additionalEntriesCount);
+    for (int i = offsetPos + 1; 2 * i < edgeOffsetsNew.length(); i++) {
+      edgeOffsetsNew.set(2 * i, edgeOffsetsNew.get(2 * i) + additionalEntriesCount);
     }
-    return newArray;
+    return new AdjacentNodes(nodesWithEdgePropertiesNew, edgeOffsetsNew);
   }
 
   /**
@@ -744,24 +741,28 @@ public abstract class NodeDb extends Node {
    * Trims the node to save storage: shrinks overallocations
    * */
   public synchronized long trim(){
+    // TODO use writer lock?
+    AdjacentNodes adjacentNodesOld = this.adjacentNodes;
     int newSize = 0;
-    for(int offsetPos = 0; 2*offsetPos < edgeOffsets.length(); offsetPos++){
-      int length = blockLength(offsetPos);
+    for (int offsetPos = 0; 2 * offsetPos < adjacentNodesOld.edgeOffsets.length(); offsetPos++) {
+      int length = blockLength(adjacentNodesOld, offsetPos);
       newSize += length;
     }
-    Object[] newArray = new Object[newSize];
+    Object[] nodesWithEdgePropertiesNew = new Object[newSize];
+    PackedIntArray edgeOffsetsNew = adjacentNodesOld.edgeOffsets.clone();
 
     int off = 0;
-    for(int offsetPos = 0; 2*offsetPos < edgeOffsets.length(); offsetPos++){
-      int start = startIndex(offsetPos);
-      int length = blockLength(offsetPos);
-      System.arraycopy(adjacentNodesWithEdgeProperties, start, newArray, off, length);
-      edgeOffsets.set(2 * offsetPos, off);
+    for(int offsetPos = 0; 2*offsetPos < adjacentNodesOld.edgeOffsets.length(); offsetPos++){
+      int start = startIndex(adjacentNodesOld, offsetPos);
+      int length = blockLength(adjacentNodesOld, offsetPos);
+      System.arraycopy(adjacentNodesOld.nodesWithEdgeProperties, start, nodesWithEdgePropertiesNew, off, length);
+      edgeOffsetsNew.set(2 * offsetPos, off);
       off += length;
     }
-    int oldsize = adjacentNodesWithEdgeProperties.length;
-    adjacentNodesWithEdgeProperties = newArray;
-    return (long)newSize + ( ((long)oldsize) << 32);
+    int oldSize = adjacentNodesOld.nodesWithEdgeProperties.length;
+    this.adjacentNodes = new AdjacentNodes(nodesWithEdgePropertiesNew, edgeOffsetsNew);
+
+    return (long) newSize + (((long) oldSize) << 32);
   }
 
   public final boolean isDirty() {

--- a/core/src/main/java/overflowdb/util/DummyEdgeIterator.java
+++ b/core/src/main/java/overflowdb/util/DummyEdgeIterator.java
@@ -17,7 +17,12 @@ public class DummyEdgeIterator implements Iterator<Edge> {
   private final String label;
   private final NodeRef thisRef;
 
-  /** used for peeking */
+  /**
+   * Used for peeking forward, and also handle a benign race condition: the given `array` can be modified from the
+   * outside, e.g. if an adjacent node or edge is removed after this Iterator was created. That's ok, but we want to at
+   * least guarantee correct Iterator semantics, i.e. if `.hasNext` returned `true`, then `.next()` should never be null
+   * or throw an exception.
+   * */
   private Edge nextCached;
 
   public DummyEdgeIterator(Object[] array, int begin, int exclusiveEnd, int strideSize,

--- a/core/src/main/java/overflowdb/util/PackedIntArray.java
+++ b/core/src/main/java/overflowdb/util/PackedIntArray.java
@@ -7,7 +7,7 @@ package overflowdb.util;
  * For the specific case with the NodeDb.edgeOffsets where the most
  * numbers fit into byte almost all the time it saves ~90Mb in a 1.3Gb heap.
  */
-public class PackedIntArray {
+public class PackedIntArray implements Cloneable {
   private static final byte BYTE_ARRAY = 0;
   private static final byte SHORT_ARRAY = 1;
   private static final byte INT_ARRAY = 2;
@@ -48,7 +48,7 @@ public class PackedIntArray {
       case BYTE_ARRAY: return ByteArrayAccessor.INSTANCE;
       case SHORT_ARRAY: return ShortArrayAccessor.INSTANCE;
       case INT_ARRAY: return IntArrayAccessor.INSTANCE;
-      default: throw new java.lang.IllegalStateException("PackedIntArray.kind has incorrect value.");
+      default: throw new java.lang.IllegalStateException("PackedIntArray.kind has incorrect value: " + kind);
     }
   }
 
@@ -178,4 +178,38 @@ public class PackedIntArray {
       return cast(o).length;
     }
   }
+
+  @Override
+  public PackedIntArray clone() {
+    try {
+      PackedIntArray copy = (PackedIntArray) super.clone();
+      final int length = length();
+      final Object newUnderlying;
+      switch (kind) {
+        case BYTE_ARRAY:
+          newUnderlying = new byte[length];
+          System.arraycopy(underlying, 0, newUnderlying, 0, length);
+          break;
+        case SHORT_ARRAY:
+          newUnderlying = new short[length];
+          System.arraycopy(underlying, 0, newUnderlying, 0, length);
+          break;
+        case INT_ARRAY:
+          newUnderlying = new int[length];
+          System.arraycopy(underlying, 0, newUnderlying, 0, length);
+          break;
+        default: throw new java.lang.IllegalStateException("PackedIntArray.kind has incorrect value: " + kind);
+      }
+      copy.underlying = newUnderlying;
+      return copy;
+    } catch (CloneNotSupportedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void clear() {
+    this.kind = BYTE_ARRAY;
+    this.underlying = new byte[0];
+  }
+
 }

--- a/core/src/test/java/overflowdb/ElementTest.java
+++ b/core/src/test/java/overflowdb/ElementTest.java
@@ -560,6 +560,25 @@ public class ElementTest {
   }
 
   @Test
+  public void shouldMaintainIteratorGuaranteesOnGraphModifications() {
+    try (Graph graph = GratefulDead.newGraph()) {
+      Node n0 = graph.addNode(Song.label, Song.NAME, "Song 1");
+      Node n2 = graph.addNode(Song.label, Song.NAME, "Song 2");
+      Edge e4 = n0.addEdge(FollowedBy.LABEL, n2);
+
+      Iterator<Edge> outE = n0.outE();
+      Iterator<Node> out = n0.out();
+      assertTrue(outE.hasNext());
+      assertTrue(out.hasNext());
+      n2.remove();
+      assertEquals(e4, outE.next());
+      assertEquals(n2, out.next());
+      assertFalse(outE.hasNext());
+      assertFalse(out.hasNext());
+    }
+  }
+
+  @Test
   public void defaultPropertyValues() {
     try (Graph graph = GratefulDead.newGraph()) {
       Node n0 = graph.addNode(Song.label, Song.NAME, "Song 1");

--- a/core/src/test/java/overflowdb/util/PackedIntArrayTest.java
+++ b/core/src/test/java/overflowdb/util/PackedIntArrayTest.java
@@ -15,7 +15,17 @@ public class PackedIntArrayTest {
   }
 
   @Test
-  public void shouldProvideGetSetOperations() {
+  public void shouldInitializeCorrectly() {
+    // should initialize as int[]
+    final PackedIntArray a = PackedIntArray.of(1, 255, Short.MAX_VALUE + 1);
+    assertEquals(1, a.get(0));
+    assertEquals(255, a.get(1));
+    assertEquals(Short.MAX_VALUE + 1, a.get(2));
+    assertEquals(3, a.length());
+  }
+
+  @Test
+  public void shouldGrowAutomatically() {
     final PackedIntArray a = PackedIntArray.of(1, 2, 3);
     assertEquals(1, a.get(0));
     assertEquals(2, a.get(1));
@@ -25,5 +35,20 @@ public class PackedIntArrayTest {
     assertEquals(255, a.get(0));
     a.set(1, Short.MAX_VALUE + 1); // should grow to int[]
     assertEquals(Short.MAX_VALUE + 1, a.get(1));
+  }
+
+  @Test
+  public void shouldAllowClone() {
+    // will create an int[]
+    final PackedIntArray a = PackedIntArray.of(1, 2, 255, Short.MAX_VALUE + 1);
+    final PackedIntArray b = a.clone();
+    // modify a to ensure we're doing a deep clone
+    a.set(0, 0);
+
+    assertEquals(1, b.get(0));
+    assertEquals(2, b.get(1));
+    assertEquals(255, b.get(2));
+    assertEquals(Short.MAX_VALUE + 1, b.get(3));
+    assertEquals(4, b.length());
   }
 }


### PR DESCRIPTION
* use writer mutex to synchronize all write operations
* use container for adjacentNodesWithEdgeProperties / edgeOffsets
* make container volatile to prevent bugs via cpu/compiler optimizations such as statement reordering
* container only needs to be recreated on `grow` and `trim` - other update operations may result in reading outdated data, but ensures better read performance
* DummyEdgeIterator: handle null case in array: hold 'peeked' entry in class: underlying array may have changed (e.g. if an edge was removed concurrently). We want to at least guarantee correct Iterator semantics, i.e. if `hasNext` was true, then `.next` should never be null or throw an exception
* related: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1319#issuecomment-894121966