### PR TITLE
Delete temporary files as early as possible.

### DIFF
--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -65,7 +65,12 @@ public class OdbStorage implements AutoCloseable {
         mvstoreFile = File.createTempFile("mvstore", ".bin");
         if (!System.getProperty("os.name").toLowerCase().contains("win")) {
           mvstoreFileStore = new FileStore();
-          mvstoreFileStore.open(mvstoreFile.getAbsolutePath(), false, null);
+          boolean readOnly = false;
+          char[] encryptionKey = null;
+          mvstoreFileStore.open(mvstoreFile.getAbsolutePath(), readOnly, encryptionKey);
+          /** Note: we're deleting the temporary storage file as early as possible on *nix systems, i.e. while it's still running
+            * This is so we don't fill up `/tmp` if the JVM gets killed.
+            **/
           mvstoreFile.delete();
         } else {
           mvstoreFile.deleteOnExit();

--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -1,5 +1,6 @@
 package overflowdb.storage;
 
+import org.h2.mvstore.FileStore;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.slf4j.Logger;
@@ -30,7 +31,7 @@ public class OdbStorage implements AutoCloseable {
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   private final File mvstoreFile;
-  private final boolean doPersist;
+  private FileStore mvstoreFileStore;
   protected MVStore mvstore;
   private MVMap<Long, byte[]> nodesMVMap;
   private MVMap<String, String> metadataMVMap;
@@ -54,7 +55,6 @@ public class OdbStorage implements AutoCloseable {
 
   private OdbStorage(final Optional<File> mvstoreFileMaybe) {
     if (mvstoreFileMaybe.isPresent()) {
-      this.doPersist = true;
       mvstoreFile = mvstoreFileMaybe.get();
       if (mvstoreFile.exists() && mvstoreFile.length() > 0) {
         verifyStorageVersion();
@@ -62,9 +62,14 @@ public class OdbStorage implements AutoCloseable {
       }
     } else {
       try {
-        this.doPersist = false;
         mvstoreFile = File.createTempFile("mvstore", ".bin");
-        mvstoreFile.deleteOnExit(); // `.close` will also delete it, this is just in case users forget to call it
+        if (!System.getProperty("os.name").toLowerCase().contains("win")) {
+          mvstoreFileStore = new FileStore();
+          mvstoreFileStore.open(mvstoreFile.getAbsolutePath(), false, null);
+          mvstoreFile.delete();
+        } else {
+          mvstoreFile.deleteOnExit();
+        }
       } catch (IOException e) {
         throw new RuntimeException("cannot create tmp file for mvstore", e);
       }
@@ -119,7 +124,6 @@ public class OdbStorage implements AutoCloseable {
     logger.debug("closing " + getClass().getSimpleName());
     flush();
     if (mvstore != null) mvstore.close();
-    if (!doPersist) mvstoreFile.delete();
   }
 
   public File getStorageFile() {
@@ -199,14 +203,18 @@ public class OdbStorage implements AutoCloseable {
   }
 
   private MVStore initializeMVStore() {
-    final MVStore store = new MVStore.Builder()
-        .fileName(mvstoreFile.getAbsolutePath())
+    MVStore.Builder builder = new MVStore.Builder()
         .autoCommitBufferSize(1024 * 8)
         .compress()
-        .autoCommitDisabled()
-        .open();
+        .autoCommitDisabled();
 
-    return store;
+    if (mvstoreFileStore != null) {
+      builder.fileStore(mvstoreFileStore);
+    } else {
+      builder.fileName(mvstoreFile.getAbsolutePath());
+    }
+
+    return builder.open();
   }
 
   private int initializeLibraryVersionsIdCurrentRun() {
@@ -227,7 +235,7 @@ public class OdbStorage implements AutoCloseable {
         .getMapNames()
         .stream()
         .filter(s -> s.startsWith(INDEX_PREFIX))
-        .collect(Collectors.toConcurrentMap(s -> removeIndexPrefix(s), s -> s));
+        .collect(Collectors.toConcurrentMap(this::removeIndexPrefix, s -> s));
   }
 
   public Set<String> getIndexNames() {

--- a/core/src/test/java/overflowdb/storage/OdbStorageTest.java
+++ b/core/src/test/java/overflowdb/storage/OdbStorageTest.java
@@ -21,6 +21,7 @@ public class OdbStorageTest {
   @Test
   public void persistToFileIfStorageConfigured() throws IOException {
     final File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
+    storageFile.deleteOnExit();
     Config config = Config.withDefaults().withStorageLocation(storageFile.getAbsolutePath());
 
     // open empty graph, add one node, close graph
@@ -47,8 +48,6 @@ public class OdbStorageTest {
     try (Graph graph = GratefulDead.newGraph(config)) {
       assertEquals(0, graph.nodeCount());
     }
-
-    storageFile.delete(); //cleanup after test
   }
 
   @Test


### PR DESCRIPTION
This means that there's no chance on *nix systems that the `/tmp` directory can end up with temporary files left over when the JVM gets killed.

At least on systems that aren't Windows, since there we can't simply delete the still open file AFAIK.

This would be cleaner if done via `StandardOpenOption.DELETE_ON_CLOSE` on the part that opens the file (in `FileStore`), however even overloading wouldn't allow us to do that, instead the whole `FileStore` interface would have to be redone I think.

Anyway, just an idea, since it doesn't require too many changes.