### PR TITLE
don't use ReferenceManager if overflow is disabled

### DIFF
--- a/core/src/main/java/overflowdb/Edge.java
+++ b/core/src/main/java/overflowdb/Edge.java
@@ -41,7 +41,7 @@ public abstract class Edge extends Element {
     this.inNode = inVertex;
 
     this.specificKeys = specificKeys;
-    graph.referenceManager.applyBackpressureMaybe();
+    graph.applyBackpressureMaybe();
   }
 
   public NodeRef outNode() {

--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -204,7 +204,7 @@ public final class Graph implements AutoCloseable {
         if (referenceManager != null) {
           referenceManager.clearAllReferences();
         } else {
-          // TODO write all to disk - just like in referencemanager - ideally factor out some logic
+          nodes.persistAll(nodesWriter);
         }
       }
     } finally {

--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -88,7 +88,8 @@ public final class Graph implements AutoCloseable {
   private void initElementCollections(OdbStorage storage) {
     long start = System.currentTimeMillis();
     final Set<Map.Entry<Long, byte[]>> serializedNodes = storage.allNodes();
-    logger.info("initializing " + serializedNodes.size() + " nodes from existing storage - this may take some time");
+    if (logger.isInfoEnabled())
+      logger.info(String.format("initializing %d nodes from existing storage", serializedNodes.size()));
     int importCount = 0;
     long maxId = currentId.get();
 
@@ -111,7 +112,8 @@ public final class Graph implements AutoCloseable {
     currentId.set(maxId + 1);
     indexManager.initializeStoredIndices(storage);
     long elapsedMillis = System.currentTimeMillis() - start;
-    logger.debug("initialized " + this.toString() + " from existing storage in " + elapsedMillis + "ms");
+    if (logger.isDebugEnabled())
+      logger.debug(String.format("initialized %s from existing storage in %sms", this, elapsedMillis));
   }
 
 

--- a/core/src/main/java/overflowdb/NodeDb.java
+++ b/core/src/main/java/overflowdb/NodeDb.java
@@ -52,7 +52,7 @@ public abstract class NodeDb extends Node {
 
     ref.setNode(this);
     if (ref.graph != null) {
-      ref.graph.referenceManager.applyBackpressureMaybe();
+      ref.graph.applyBackpressureMaybe();
     }
 
     adjacentNodes = new AdjacentNodes(layoutInformation().numberOfDifferentAdjacentTypes());

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -55,8 +55,8 @@ public abstract class NodeRef<N extends NodeDb> extends Node {
     return node == null;
   }
 
-  /* only called by @ReferenceManager */
-  protected void clear() {
+  /* only supposed to be called by @NodesWriter */
+  public void clear() {
     this.node = null;
   }
 

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -101,7 +101,7 @@ public abstract class NodeRef<N extends NodeDb> extends Node {
       final N node = readFromDisk(id);
       if (node == null) throw new IllegalStateException("unable to read node from disk; id=" + id);
       this.node = node;
-      graph.referenceManager.registerRef(this); // so it can be cleared on low memory
+      graph.registerNodeRef(this);
       return node;
     }
   }

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -55,9 +55,13 @@ public abstract class NodeRef<N extends NodeDb> extends Node {
     return node == null;
   }
 
-  /* only supposed to be called by @NodesWriter */
-  public void clear() {
-    this.node = null;
+  /**
+   * Only supposed to be called by @NodesWriter
+   * We'd prefer this to be package-private, but since NodesWriter is in a different package that's not an option in java.
+   * To not pollute the public api (esp. for console users) we made this method static instead.
+   * */
+  public static void clear(NodeRef ref) {
+    ref.node = null;
   }
 
   protected byte[] serializeWhenDirty() {
@@ -133,7 +137,7 @@ public abstract class NodeRef<N extends NodeDb> extends Node {
   @Override
   public void remove() {
     get().remove();
-    clear();
+    NodeRef.clear(this);
   }
 
   @Override

--- a/core/src/main/java/overflowdb/ReferenceManager.java
+++ b/core/src/main/java/overflowdb/ReferenceManager.java
@@ -39,13 +39,14 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
     this.storage = storage;
   }
 
+  /* Register NodeRef, so it can be cleared on low memory */
   public void registerRef(NodeRef ref) {
     clearableRefs.add(ref);
   }
 
   /**
-   * when we're running low on heap memory we'll serialize some elements to disk. to ensure we're not creating new ones
-   * faster than old ones are serialized away, we're applying some backpressure in those situation
+   * When we're running low on heap memory we'll serialize some elements to disk. To ensure we're not creating new ones
+   * faster than old ones are serialized away, we're applying some backpressure to those newly created ones.
    */
   public void applyBackpressureMaybe() {
     synchronized (backPressureSyncObject) {

--- a/core/src/main/java/overflowdb/ReferenceManager.java
+++ b/core/src/main/java/overflowdb/ReferenceManager.java
@@ -116,7 +116,7 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
       synchronized (backPressureSyncObject) {
         clearingProcessCount += 1;
       }
-      clearReferences(refsToClear);
+      nodesWriter.writeAndClearBatched(refsToClear.spliterator(), refsToClear.size());
       storage.flush();
     } catch (Exception e) {
       logger.error("error while trying to clear references", e);
@@ -135,26 +135,7 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
    * useful when saving the graph
    */
   public void clearAllReferences() {
-//    int initialRefCount = clearableRefs.size();
-//    int clearedCount = 0;
-//    while (!clearableRefs.isEmpty()) {
-//      try {
-//        final List<NodeRef> refsToClear = collectRefsToClear(releaseCount);
-//        if (!refsToClear.isEmpty()) {
-//          int clearCountCurr = refsToClear.size();
-//          safelyClearReferences(refsToClear);
-//          clearedCount += clearCountCurr;
-//        }
-//
-//        if (logger.isInfoEnabled()) {
-//          float progressPercent = 100f * clearedCount / initialRefCount;
-//          logger.info(String.format("progress of clearing references: %.2f%s", Float.min(100f, progressPercent), "%"));
-//        }
-//      } catch (Exception e) {
-//        throw new RuntimeException("error while clearing references to disk", e);
-//      }
-//    }
-    nodesWriter.writeAndClearBatched((ArrayList<Node>) clearableRefs);
+    nodesWriter.writeAndClearBatched(clearableRefs.spliterator(), clearableRefs.size());
     logger.info("cleared all clearable references");
   }
 

--- a/core/src/main/java/overflowdb/storage/NodesWriter.java
+++ b/core/src/main/java/overflowdb/storage/NodesWriter.java
@@ -47,7 +47,7 @@ public class NodesWriter {
         try {
           byte[] bytes = nodeSerializer.serialize(nodeDb);
           storage.persist(ref.id(), bytes);
-          ref.clear();
+          NodeRef.clear(ref);
         } catch (IOException e) {
           throw new RuntimeException(e);
         }

--- a/core/src/main/java/overflowdb/storage/NodesWriter.java
+++ b/core/src/main/java/overflowdb/storage/NodesWriter.java
@@ -1,0 +1,68 @@
+package overflowdb.storage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import overflowdb.Node;
+import overflowdb.NodeDb;
+import overflowdb.NodeRef;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Persists collections of nodes in bulk to disk. Used either by ReferenceManager (if overflow to disk is enabled),
+ * or alternatively when closing the graph (if storage to disk is enabled).
+ */
+public class NodesWriter {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final boolean isLogInfoEnabled = logger.isInfoEnabled();
+  public final int batchSize = 100000;
+  private final NodeSerializer nodeSerializer;
+  private final OdbStorage storage;
+
+  public NodesWriter(NodeSerializer nodeSerializer, OdbStorage storage) {
+    this.nodeSerializer = nodeSerializer;
+    this.storage = storage;
+  }
+
+  /**
+   * writes all references to storage, blocks until complete.
+   *
+   * @return number of persisted nodes
+   */
+  public int writeAndClearBatched(ArrayList<Node> nodes) {
+    AtomicInteger count = new AtomicInteger(0);
+    nodes.parallelStream().forEach(node -> {
+      NodeDb nodeDb = null;
+      NodeRef ref = null;
+      if (node instanceof NodeDb) {
+        nodeDb = (NodeDb) node;
+        ref = nodeDb.ref;
+      } else if (node instanceof NodeRef) {
+        ref = (NodeRef) node;
+        if (ref.isSet()) nodeDb = ref.get();
+      }
+
+      if (nodeDb.isDirty()) {
+        try {
+          byte[] bytes = nodeSerializer.serialize(nodeDb);
+          storage.persist(ref.id(), bytes);
+          ref.clear();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      int currCount = count.incrementAndGet();
+      // log status every now and then (once in 2^16 times, i.e. once in 131072 times)
+      if (isLogInfoEnabled && currCount >> 17 == 0) {
+        float progressPercent = 100f * currCount / nodes.size();
+        logger.info(String.format("progress of writing nodes to storage: %.2f%s", Float.min(100f, progressPercent), "%"));
+      }
+    });
+
+    return count.get();
+  }
+
+}

--- a/core/src/main/java/overflowdb/storage/NodesWriter.java
+++ b/core/src/main/java/overflowdb/storage/NodesWriter.java
@@ -17,7 +17,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class NodesWriter {
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final boolean isLogInfoEnabled = logger.isInfoEnabled();
-  public final int batchSize = 100000;
   private final NodeSerializer nodeSerializer;
   private final OdbStorage storage;
 

--- a/core/src/main/java/overflowdb/util/NodesList.java
+++ b/core/src/main/java/overflowdb/util/NodesList.java
@@ -5,14 +5,9 @@ import gnu.trove.map.TMap;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.map.hash.TLongIntHashMap;
 import overflowdb.Node;
+import overflowdb.storage.NodesWriter;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import java.util.*;
 
 public class NodesList {
   private Node[] nodes;
@@ -218,6 +213,10 @@ public class NodesList {
       return nodesByLabel.get(label).size();
     else
       return 0;
+  }
+
+  public synchronized void persistAll(NodesWriter nodesWriter) {
+    nodesWriter.writeAndClearBatched(Arrays.spliterator(nodes), nodes.length);
   }
 
   public static class NodesIterator implements Iterator<Node> {

--- a/core/src/test/java/overflowdb/ElementTest.java
+++ b/core/src/test/java/overflowdb/ElementTest.java
@@ -283,7 +283,6 @@ public class ElementTest {
       n0.addEdge(TestEdge.LABEL, n1, TestEdge.LONG_PROPERTY, 1l);
 
       // round trip serialization, delete edge with longProperty=0;
-      graph.referenceManager.clearAllReferences();
       graph.node(n0.id()).outE().forEachRemaining(edge -> {
         if (0L == (long) edge.property(TestEdge.LONG_PROPERTY)) {
           edge.remove();

--- a/core/src/test/java/overflowdb/storage/SerializerTest.java
+++ b/core/src/test/java/overflowdb/storage/SerializerTest.java
@@ -143,9 +143,9 @@ public class SerializerTest {
     assertEquals("DEFAULT_STRING_VALUE", testNode1.property(stringPropertyKey));
     assertEquals("DEFAULT_STRING_VALUE", testNode1.propertiesMap().get(stringPropertyKey));
     assertFalse(testNode1.get().propertiesMapForStorage().containsKey(stringPropertyKey));
-    assertEquals(new Long(-99l), testEdge.longProperty());
-    assertEquals(new Long(-99l), testEdge.property(longPropertyKey));
-    assertEquals(new Long(-99l), testEdge.propertiesMap().get(longPropertyKey));
+    assertEquals(Long.valueOf(-99l), testEdge.longProperty());
+    assertEquals(-99l, testEdge.property(longPropertyKey));
+    assertEquals(-99l, testEdge.propertiesMap().get(longPropertyKey));
     graph.close();
 
     // to verify that default property values are not serialized, we're reopening the graph with different `default value` settings
@@ -162,9 +162,9 @@ public class SerializerTest {
     assertEquals("NEW_DEFAULT_STRING_VALUE", n1Deserialized.property(stringPropertyKey));
     assertEquals("NEW_DEFAULT_STRING_VALUE", n1Deserialized.propertiesMap().get(stringPropertyKey));
     assertFalse(n1Deserialized.get().propertiesMapForStorage().containsKey(stringPropertyKey));
-    assertEquals(new Long(-49l), edge1Deserialized.longProperty());
-    assertEquals(new Long(-49l), edge1Deserialized.property(longPropertyKey));
-    assertEquals(new Long(-49l), edge1Deserialized.propertiesMap().get(longPropertyKey));
+    assertEquals(Long.valueOf(-49l), edge1Deserialized.longProperty());
+    assertEquals(-49l, edge1Deserialized.property(longPropertyKey));
+    assertEquals(-49l, edge1Deserialized.propertiesMap().get(longPropertyKey));
   }
 
   private NodeDeserializer newDeserializer(Graph graph) {


### PR DESCRIPTION
For now this is mostly a cleanup/refactoring exercise, but we'll also save a bit of memory by not holding the 'clearable refs' queue in ReferenceManager. More importantly, this is a prerequisite for a different optimisation that I'm working on.