### PR TITLE
build on jdk8 again

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,11 +7,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 8
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
         run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 8
       - uses: actions/cache@v2
         with:
           path: |

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,7 @@ lazy val traversal = project.in(file("traversal"))
                        .dependsOn(tinkerpop3 % "test->test") // TODO drop this dependency - currently necessary for GratefulDeadTest which uses graphml loading
 
 ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature", "-target:jvm-1.8")
-ThisBuild/javacOptions ++= Seq("-source", "1.8")
-ThisBuild/Test/compile/javacOptions ++= Seq("-g", "-target", "1.8")
+ThisBuild/javacOptions ++= Seq("-g")
 ThisBuild/Test/testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v")
 ThisBuild/Test/fork := true
 


### PR DESCRIPTION
We never wanted to stop targeting jdk8, and the recent upgrade to
building on jdk11 while keeping the source/target params to 1.8 did
not work. Buildiung on jdk8 again is the safest bet for now.