### PR TITLE
Reduce the amount of logging when persisting nodes

### DIFF
--- a/core/src/main/java/overflowdb/ReferenceManager.java
+++ b/core/src/main/java/overflowdb/ReferenceManager.java
@@ -136,7 +136,7 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
    */
   public void clearAllReferences() {
     nodesWriter.writeAndClearBatched(clearableRefs.spliterator(), clearableRefs.size());
-    logger.info("cleared all clearable references");
+    logger.debug("cleared all clearable references");
   }
 
   @Override

--- a/core/src/main/java/overflowdb/storage/NodesWriter.java
+++ b/core/src/main/java/overflowdb/storage/NodesWriter.java
@@ -32,7 +32,7 @@ public class NodesWriter {
    */
   public void writeAndClearBatched(Spliterator<? extends Node> nodes, int estimatedTotalCount) {
     if (estimatedTotalCount > 0)
-      logger.info(String.format("START: serializing and persisting %d nodes", estimatedTotalCount));
+      logger.info(String.format("serializing and persisting %d nodes (this may take a while)", estimatedTotalCount));
 
     AtomicInteger count = new AtomicInteger(0);
 
@@ -48,13 +48,13 @@ public class NodesWriter {
             int currCount = count.incrementAndGet();
             if (currCount % 100_000 == 0) {
                float progressPercent = 100f * currCount / estimatedTotalCount;
-               logger.info(String.format("progress of writing nodes to storage: %.2f%s", Float.min(100f, progressPercent), "%"));
+               logger.debug(String.format("progress of writing nodes to storage: %.2f%s", Float.min(100f, progressPercent), "%"));
             }
           }
         });
 
     if (estimatedTotalCount > 0)
-      logger.info(String.format("END: serializing and persisting %d nodes", estimatedTotalCount));
+      logger.info(String.format("finished serializing and persisting %d nodes", estimatedTotalCount));
   }
   private SerializedNode serializeIfDirty(Node node) {
     NodeDb nodeDb = null;


### PR DESCRIPTION
Persisting nodes may produce a lot of logs which is not particularly
interesting when running frontends with INFO level.
This change is pretty subjective but in general that level of logging is
not necessary for regular users.