### PR TITLE
remove superfluous checks in logger where not on hot path

### DIFF
--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -88,8 +88,7 @@ public final class Graph implements AutoCloseable {
   private void initElementCollections(OdbStorage storage) {
     long start = System.currentTimeMillis();
     final Set<Map.Entry<Long, byte[]>> serializedNodes = storage.allNodes();
-    if (logger.isInfoEnabled())
-      logger.info(String.format("initializing %d nodes from existing storage", serializedNodes.size()));
+    logger.info(String.format("initializing %d nodes from existing storage", serializedNodes.size()));
     int importCount = 0;
     long maxId = currentId.get();
 
@@ -112,8 +111,7 @@ public final class Graph implements AutoCloseable {
     currentId.set(maxId + 1);
     indexManager.initializeStoredIndices(storage);
     long elapsedMillis = System.currentTimeMillis() - start;
-    if (logger.isDebugEnabled())
-      logger.debug(String.format("initialized %s from existing storage in %sms", this, elapsedMillis));
+    logger.debug(String.format("initialized %s from existing storage in %sms", this, elapsedMillis));
   }
 
 

--- a/core/src/main/java/overflowdb/ReferenceManager.java
+++ b/core/src/main/java/overflowdb/ReferenceManager.java
@@ -54,9 +54,9 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
     synchronized (backPressureSyncObject) {
       while (clearingProcessCount > 0) {
         try {
-          if (logger.isTraceEnabled()) logger.trace("wait until ref clearing completed");
+          logger.trace("wait until ref clearing completed");
           backPressureSyncObject.wait();
-          if (logger.isTraceEnabled()) logger.trace("continue");
+          logger.trace("continue");
         } catch (InterruptedException e) {
           throw new RuntimeException(e);
         }
@@ -72,7 +72,7 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
       logger.info("no refs to clear at the moment, i.e. the heap is used by other components");
     } else {
       int releaseCount = Integer.min(this.releaseCount, clearableRefs.size());
-      if (logger.isInfoEnabled()) logger.info("scheduled to clear " + releaseCount + " references (asynchronously)");
+      logger.info("scheduled to clear " + releaseCount + " references (asynchronously)");
       singleThreadExecutor.submit(() -> syncClearReferences(releaseCount));
     }
   }
@@ -85,9 +85,9 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
     final List<NodeRef> refsToClear = collectRefsToClear(releaseCount);
     if (!refsToClear.isEmpty()) {
       safelyClearReferences(refsToClear);
-      if (logger.isInfoEnabled()) logger.info("completed clearing of " + refsToClear.size() + " references");
-      if (logger.isDebugEnabled()) logger.debug("remaining clearable references: " + clearableRefs.size());
-      if (logger.isTraceEnabled()) logger.trace("references cleared in total: " + totalReleaseCount);
+      logger.info("completed clearing of " + refsToClear.size() + " references");
+      logger.debug("remaining clearable references: " + clearableRefs.size());
+      logger.trace("references cleared in total: " + totalReleaseCount);
     }
   }
 


### PR DESCRIPTION
these checks only make sense when we're on the hot path - remove them
in favor for better readability and less clutter