### PR TITLE
Fix NPE in DiffTool

### DIFF
--- a/core/src/main/java/overflowdb/util/DiffTool.java
+++ b/core/src/main/java/overflowdb/util/DiffTool.java
@@ -58,9 +58,10 @@ public class DiffTool {
     propertyKeys.forEach(key -> {
       final Object value1 = properties1.get(key);
       final Object value2 = properties2.get(key);
-      if (!value1.equals(value2)) diff.add(String.format("%s; property '%s' has different values: graph1='%s', graph2='%s'", context, key, value1, value2));
-      else if (value1 == null) diff.add(String.format("%s; property '%s' -> '%s' only exists in graph2", context, key, value2));
+
+      if (value1 == null) diff.add(String.format("%s; property '%s' -> '%s' only exists in graph2", context, key, value2));
       else if (value2 == null) diff.add(String.format("%s; property '%s' -> '%s' only exists in graph1", context, key, value1));
+      else if (!value1.equals(value2)) diff.add(String.format("%s; property '%s' has different values: graph1='%s', graph2='%s'", context, key, value1, value2));
     });
 
   }

--- a/core/src/test/java/overflowdb/util/DiffToolTest.java
+++ b/core/src/test/java/overflowdb/util/DiffToolTest.java
@@ -1,0 +1,91 @@
+package overflowdb.util;
+
+import org.junit.Test;
+import overflowdb.Graph;
+import overflowdb.Node;
+import overflowdb.testdomains.simple.SimpleDomain;
+import overflowdb.testdomains.simple.TestEdge;
+import overflowdb.testdomains.simple.TestNode;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+public class DiffToolTest {
+
+    @Test
+    public void returnEmptyListForTheSameGraph() {
+        Graph graph0 = SimpleDomain.newGraph();
+        Node g0n0 = graph0.addNode(TestNode.LABEL, TestNode.INT_PROPERTY, 0);
+        Node g0n1 = graph0.addNode(TestNode.LABEL, TestNode.INT_PROPERTY, 1);
+        g0n0.addEdge(TestEdge.LABEL, g0n1, TestEdge.LONG_PROPERTY, 1l);
+
+        List<String> diffRes = DiffTool.compare(graph0, graph0);
+
+        assertTrue(diffRes.isEmpty());
+    }
+
+    @Test
+    public void returnEmptyListForTheCopyOfTheGraph() {
+        Graph graph0 = SimpleDomain.newGraph();
+        Node g0n0 = graph0.addNode(TestNode.LABEL, TestNode.INT_PROPERTY, 0);
+        Node g0n1 = graph0.addNode(TestNode.LABEL, TestNode.INT_PROPERTY, 1);
+        g0n0.addEdge(TestEdge.LABEL, g0n1, TestEdge.LONG_PROPERTY, 1l);
+
+        Graph graph1 = SimpleDomain.newGraph();
+        Node g1n0 = graph1.addNode(TestNode.LABEL, TestNode.INT_PROPERTY, 0);
+        Node g1n1 = graph1.addNode(TestNode.LABEL, TestNode.INT_PROPERTY, 1);
+        g1n0.addEdge(TestEdge.LABEL, g1n1, TestEdge.LONG_PROPERTY, 1l);
+
+        List<String> diffRes = DiffTool.compare(graph0, graph1);
+        assertTrue(diffRes.isEmpty());
+
+        // TODO: commutative property would be a good candidate for property based testing
+        List<String> diffRes2 = DiffTool.compare(graph1, graph0);
+        assertTrue(diffRes2.isEmpty());
+    }
+
+    @Test
+    public void returnSomeDifferencesIfOneGraphHasMoreNodeProperties() {
+        Graph graph0 = SimpleDomain.newGraph();
+        Node g0n0 = graph0.addNode(TestNode.LABEL, TestNode.INT_PROPERTY, 0);
+        Node g0n1 = graph0.addNode(TestNode.LABEL, TestNode.INT_PROPERTY, 1);
+        g0n0.addEdge(TestEdge.LABEL, g0n1, TestEdge.LONG_PROPERTY, 1l);
+
+        Graph graph1 = SimpleDomain.newGraph();
+        Node g1n0 = graph1.addNode(TestNode.LABEL);
+        Node g1n1 = graph1.addNode(TestNode.LABEL);
+        g1n0.addEdge(TestEdge.LABEL, g1n1, TestEdge.LONG_PROPERTY, 1l);
+
+        List<String> diffRes = DiffTool.compare(graph0, graph1);
+        assertTrue(!diffRes.isEmpty());
+
+        List<String> diffRes2 = DiffTool.compare(graph1, graph0);
+
+        assertTrue(!diffRes2.isEmpty());
+        // TODO: ideally we would diffRes == diffRes2 but right not it will not work as the returned strings are different
+        assertTrue(diffRes.size() == diffRes2.size());
+    }
+
+    @Test
+    public void returnSomeDifferencesIfOneGraphHasMoreEdges() {
+        Graph graph0 = SimpleDomain.newGraph();
+        Node g0n0 = graph0.addNode(TestNode.LABEL);
+        Node g0n1 = graph0.addNode(TestNode.LABEL);
+        g0n0.addEdge(TestEdge.LABEL, g0n1, TestEdge.LONG_PROPERTY, 1l);
+
+        Graph graph1 = SimpleDomain.newGraph();
+        graph1.addNode(TestNode.LABEL);
+        graph1.addNode(TestNode.LABEL);
+
+        List<String> diffRes = DiffTool.compare(graph0, graph1);
+        assertTrue(!diffRes.isEmpty());
+
+        List<String> diffRes2 = DiffTool.compare(graph1, graph0);
+
+        assertTrue(!diffRes2.isEmpty());
+        // TODO: ideally we would diffRes == diffRes2 but right not it will not work as the returned strings are different
+        assertTrue(diffRes.size() == diffRes2.size());
+    }
+
+}


### PR DESCRIPTION
Added `DiffToolTest`

`DiffToolTest.returnSomeDifferencesIfOneGraphHasMoreNodeProperties` was failing with the previous version of the code