### PR TITLE
Make RepeatStep iterator reusable.

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/PathAwareRepeatStep.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/PathAwareRepeatStep.scala
@@ -3,90 +3,92 @@ package overflowdb.traversal
 import overflowdb.traversal.RepeatStep._
 import overflowdb.traversal.RepeatBehaviour.SearchAlgorithm
 
-import scala.collection.{Iterator, mutable}
+import scala.collection.{mutable, Iterator}
 
 object PathAwareRepeatStep {
+  case class WorklistItem[A](traversal: Traversal[A], depth: Int)
 
   /** @see [[Traversal.repeat]] for a detailed overview
-   *
-   * Implementation note: using recursion results in nicer code, but uses the JVM stack, which only has enough space
-   * for ~10k steps. So instead, this uses a programmatic Stack which is semantically identical.
-   * The RepeatTraversalTests cover this case.
-   * */
-  def apply[A](repeatTraversal: Traversal[A] => Traversal[A], behaviour: RepeatBehaviour[A]): A => PathAwareTraversal[A] = {
-    val worklist: Worklist[A] = behaviour.searchAlgorithm match {
-      case SearchAlgorithm.DepthFirst   => new LifoWorklist[A]
-      case SearchAlgorithm.BreadthFirst => new FifoWorklist[A]
-    }
-
-    element: A => new PathAwareTraversal[A](new Iterator[(A, Vector[Any])] {
-      val visited = mutable.Set.empty[A]
-      val emitSack: mutable.Queue[(A, Vector[Any])] = mutable.Queue.empty
-      worklist.addItem(WorklistItem(PathAwareTraversal.fromSingle(element), 0))
-
-      def hasNext: Boolean = {
-        if (emitSack.isEmpty) {
-          // this may add elements to the emit sack and/or modify the worklist
-          traverseOnWorklist
+    *
+    * Implementation note: using recursion results in nicer code, but uses the JVM stack, which only has enough space
+    * for ~10k steps. So instead, this uses a programmatic Stack which is semantically identical.
+    * The RepeatTraversalTests cover this case.
+    * */
+  def apply[A](repeatTraversal: Traversal[A] => Traversal[A],
+               behaviour: RepeatBehaviour[A]): A => PathAwareTraversal[A] = {
+    element: A =>
+      new PathAwareTraversal[A](new Iterator[(A, Vector[Any])] {
+        val visited = mutable.Set.empty[A]
+        val emitSack: mutable.Queue[(A, Vector[Any])] = mutable.Queue.empty
+        val worklist: Worklist[WorklistItem[A]] = behaviour.searchAlgorithm match {
+          case SearchAlgorithm.DepthFirst   => new LifoWorklist()
+          case SearchAlgorithm.BreadthFirst => new FifoWorklist()
         }
-        emitSack.nonEmpty || worklistTopHasNext
-      }
 
-      private def traverseOnWorklist: Unit = {
-        var stop = false
-        while (worklist.nonEmpty && !stop) {
-          val WorklistItem(trav0, depth) = worklist.head
-          val trav = trav0.path
-          if (trav.isEmpty) worklist.removeHead()
-          else if (behaviour.timesReached(depth)) stop = true
-          else {
-            val path0 = trav.next()
-            val (path1, elementInSeq) = path0.splitAt(path0.size - 1)
-            val element = elementInSeq.head.asInstanceOf[A]
-            if (behaviour.dedupEnabled) visited.addOne(element)
-            if (
-              // `while/repeat` behaviour, i.e. check every time
-              behaviour.whileConditionIsDefinedAndEmpty(element) ||
-              // `repeat/until` behaviour, i.e. only checking the `until` condition from depth 1
-              (depth > 0 && behaviour.untilConditionReached(element))) {
-              // we just consumed an element from the traversal, so in lieu adding to the emit sack
-              emitSack.enqueue((element, path1))
-              stop = true
-            } else {
-              val nextLevelTraversal = {
-                val repeat = repeatTraversal(new PathAwareTraversal(Iterator.single((element, path1))))
-                if (behaviour.dedupEnabled) repeat.filterNot(visited.contains)
-                else repeat
-              }
-              worklist.addItem(WorklistItem(nextLevelTraversal, depth + 1))
+        worklist.addItem(WorklistItem(PathAwareTraversal.fromSingle(element), 0))
 
-              if (behaviour.shouldEmit(element, depth))
+        def hasNext: Boolean = {
+          if (emitSack.isEmpty) {
+            // this may add elements to the emit sack and/or modify the worklist
+            traverseOnWorklist
+          }
+          emitSack.nonEmpty || worklistTopHasNext
+        }
+
+        private def traverseOnWorklist: Unit = {
+          var stop = false
+          while (worklist.nonEmpty && !stop) {
+            val WorklistItem(trav0, depth) = worklist.head
+            val trav = trav0.path
+            if (trav.isEmpty) worklist.removeHead()
+            else if (behaviour.timesReached(depth)) stop = true
+            else {
+              val path0 = trav.next()
+              val (path1, elementInSeq) = path0.splitAt(path0.size - 1)
+              val element = elementInSeq.head.asInstanceOf[A]
+              if (behaviour.dedupEnabled) visited.addOne(element)
+              if (// `while/repeat` behaviour, i.e. check every time
+                  behaviour.whileConditionIsDefinedAndEmpty(element) ||
+                  // `repeat/until` behaviour, i.e. only checking the `until` condition from depth 1
+                  (depth > 0 && behaviour.untilConditionReached(element))) {
+                // we just consumed an element from the traversal, so in lieu adding to the emit sack
                 emitSack.enqueue((element, path1))
-
-              if (emitSack.nonEmpty)
                 stop = true
+              } else {
+                val nextLevelTraversal = {
+                  val repeat =
+                    repeatTraversal(new PathAwareTraversal(Iterator.single((element, path1))))
+                  if (behaviour.dedupEnabled) repeat.filterNot(visited.contains)
+                  else repeat
+                }
+                worklist.addItem(WorklistItem(nextLevelTraversal, depth + 1))
+
+                if (behaviour.shouldEmit(element, depth))
+                  emitSack.enqueue((element, path1))
+
+                if (emitSack.nonEmpty)
+                  stop = true
+              }
             }
           }
         }
-      }
 
-      private def worklistTopHasNext: Boolean =
-        worklist.nonEmpty && worklist.head.traversal.hasNext
+        private def worklistTopHasNext: Boolean =
+          worklist.nonEmpty && worklist.head.traversal.hasNext
 
-      override def next(): (A, Vector[Any]) = {
-        val result = {
-          if (emitSack.hasNext) emitSack.dequeue()
-          else if (worklistTopHasNext) {
-            val entirePath = worklist.head.traversal.path.next()
-            val (path, lastElement) = entirePath.splitAt(entirePath.size - 1)
-            (lastElement.head.asInstanceOf[A], path)
+        override def next(): (A, Vector[Any]) = {
+          val result = {
+            if (emitSack.hasNext) emitSack.dequeue()
+            else if (worklistTopHasNext) {
+              val entirePath = worklist.head.traversal.path.next()
+              val (path, lastElement) = entirePath.splitAt(entirePath.size - 1)
+              (lastElement.head.asInstanceOf[A], path)
+            } else throw new NoSuchElementException("next on empty iterator")
           }
-          else throw new NoSuchElementException("next on empty iterator")
+          if (behaviour.dedupEnabled) visited.addOne(result._1)
+          result
         }
-        if (behaviour.dedupEnabled) visited.addOne(result._1)
-        result
-      }
-    })
+      })
   }
 
 }

--- a/traversal/src/main/scala/overflowdb/traversal/RepeatBehaviour.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/RepeatBehaviour.scala
@@ -2,7 +2,7 @@ package overflowdb.traversal
 
 import RepeatBehaviour._
 
-trait RepeatBehaviour[A] { this: EmitBehaviour =>
+trait RepeatBehaviour[A] {
   val searchAlgorithm: SearchAlgorithm.Value
   val untilCondition: Option[A => Iterator[_]]
   val whileCondition: Option[A => Iterator[_]]
@@ -30,11 +30,6 @@ trait RepeatBehaviour[A] { this: EmitBehaviour =>
 }
 
 object RepeatBehaviour {
-  sealed trait EmitBehaviour
-  trait EmitNothing extends EmitBehaviour
-  trait EmitAll extends EmitBehaviour
-  trait EmitAllButFirst extends EmitBehaviour
-  trait EmitConditional[A] extends EmitBehaviour
 
   object SearchAlgorithm extends Enumeration {
     type SearchAlgorithm = Value
@@ -117,7 +112,7 @@ object RepeatBehaviour {
 
     private[traversal] def build: RepeatBehaviour[A] = {
       if (_emitNothing) {
-        new RepeatBehaviour[A] with EmitNothing {
+        new RepeatBehaviour[A] {
           override val searchAlgorithm: SearchAlgorithm.Value = _searchAlgorithm
           override val untilCondition = _untilCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
           override val whileCondition = _whileCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
@@ -126,7 +121,7 @@ object RepeatBehaviour {
           override def shouldEmit(element: A, currentDepth: Int): Boolean = false
         }
       } else if (_emitAll) {
-        new RepeatBehaviour[A] with EmitAll {
+        new RepeatBehaviour[A] {
           override val searchAlgorithm: SearchAlgorithm.Value = _searchAlgorithm
           override val untilCondition = _untilCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
           override val whileCondition = _whileCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
@@ -135,7 +130,7 @@ object RepeatBehaviour {
           override def shouldEmit(element: A, currentDepth: Int): Boolean = true
         }
       } else if (_emitAllButFirst) {
-        new RepeatBehaviour[A] with EmitAllButFirst {
+        new RepeatBehaviour[A] {
           override val searchAlgorithm: SearchAlgorithm.Value = _searchAlgorithm
           override val untilCondition = _untilCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
           override val whileCondition = _whileCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
@@ -145,7 +140,7 @@ object RepeatBehaviour {
         }
       } else {
         val __emitCondition = _emitCondition
-        new RepeatBehaviour[A] with EmitConditional[A] {
+        new RepeatBehaviour[A] {
           override val searchAlgorithm: SearchAlgorithm.Value = _searchAlgorithm
           override val untilCondition = _untilCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
           override val whileCondition = _whileCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))

--- a/traversal/src/main/scala/overflowdb/traversal/RepeatBehaviour.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/RepeatBehaviour.scala
@@ -4,8 +4,8 @@ import RepeatBehaviour._
 
 trait RepeatBehaviour[A] { this: EmitBehaviour =>
   val searchAlgorithm: SearchAlgorithm.Value
-  val untilCondition: Option[Traversal[A] => Traversal[_]]
-  val whileCondition: Option[Traversal[A] => Traversal[_]]
+  val untilCondition: Option[A => Iterator[_]]
+  val whileCondition: Option[A => Iterator[_]]
   val times: Option[Int]
   val dedupEnabled: Boolean
 
@@ -14,14 +14,14 @@ trait RepeatBehaviour[A] { this: EmitBehaviour =>
 
   def untilConditionReached(element: A): Boolean =
     untilCondition match {
-      case Some(untilConditionTraversal) => untilConditionTraversal(Traversal.fromSingle(element)).hasNext
+      case Some(untilConditionTraversal) => untilConditionTraversal(element).hasNext
       case None => false
     }
 
   def whileConditionIsDefinedAndEmpty(element: A): Boolean =
     whileCondition match {
       case Some(whileConditionTraversal) =>
-        whileConditionTraversal(Traversal.fromSingle(element)).isEmpty
+        whileConditionTraversal(element).isEmpty
       case None =>
         false
     }
@@ -119,8 +119,8 @@ object RepeatBehaviour {
       if (_emitNothing) {
         new RepeatBehaviour[A] with EmitNothing {
           override val searchAlgorithm: SearchAlgorithm.Value = _searchAlgorithm
-          override val untilCondition = _untilCondition
-          override val whileCondition = _whileCondition
+          override val untilCondition = _untilCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
+          override val whileCondition = _whileCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
           final override val times: Option[Int] = _times
           final override val dedupEnabled = _dedupEnabled
           override def shouldEmit(element: A, currentDepth: Int): Boolean = false
@@ -128,8 +128,8 @@ object RepeatBehaviour {
       } else if (_emitAll) {
         new RepeatBehaviour[A] with EmitAll {
           override val searchAlgorithm: SearchAlgorithm.Value = _searchAlgorithm
-          override val untilCondition = _untilCondition
-          override val whileCondition = _whileCondition
+          override val untilCondition = _untilCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
+          override val whileCondition = _whileCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
           final override val times: Option[Int] = _times
           final override val dedupEnabled = _dedupEnabled
           override def shouldEmit(element: A, currentDepth: Int): Boolean = true
@@ -137,8 +137,8 @@ object RepeatBehaviour {
       } else if (_emitAllButFirst) {
         new RepeatBehaviour[A] with EmitAllButFirst {
           override val searchAlgorithm: SearchAlgorithm.Value = _searchAlgorithm
-          override val untilCondition = _untilCondition
-          override val whileCondition = _whileCondition
+          override val untilCondition = _untilCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
+          override val whileCondition = _whileCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
           final override val times: Option[Int] = _times
           final override val dedupEnabled = _dedupEnabled
           override def shouldEmit(element: A, currentDepth: Int): Boolean = currentDepth > 0
@@ -147,8 +147,8 @@ object RepeatBehaviour {
         val __emitCondition = _emitCondition
         new RepeatBehaviour[A] with EmitConditional[A] {
           override val searchAlgorithm: SearchAlgorithm.Value = _searchAlgorithm
-          override val untilCondition = _untilCondition
-          override val whileCondition = _whileCondition
+          override val untilCondition = _untilCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
+          override val whileCondition = _whileCondition.map(_.andThen(_.iterator).compose(Traversal.fromSingle))
           final private val _emitCondition = __emitCondition.get
           final override val times: Option[Int] = _times
           final override val dedupEnabled = _dedupEnabled

--- a/traversal/src/main/scala/overflowdb/traversal/RepeatStep.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/RepeatStep.scala
@@ -1,97 +1,38 @@
 package overflowdb.traversal
 
 import overflowdb.traversal.RepeatBehaviour.SearchAlgorithm
+import overflowdb.traversal.RepeatStep.{FifoWorklist, LifoWorklist, Worklist, WorklistItem}
 
-import scala.collection.{Iterator, mutable}
+import scala.collection.{mutable, Iterator}
 
 object RepeatStep {
 
   /** @see [[Traversal.repeat]] for a detailed overview
-   *
-   * Implementation note: using recursion results in nicer code, but uses the JVM stack, which only has enough space
-   * for ~10k steps. So instead, this uses a programmatic Stack which is semantically identical.
-   * The RepeatTraversalTests cover this case.
-   * */
-  def apply[A](repeatTraversal: Traversal[A] => Traversal[A], behaviour: RepeatBehaviour[A]): A => Traversal[A] = {
-    val worklist: Worklist[A] = behaviour.searchAlgorithm match {
-      case SearchAlgorithm.DepthFirst   => new LifoWorklist[A]
-      case SearchAlgorithm.BreadthFirst => new FifoWorklist[A]
-    }
-
-    element: A => Traversal(new Iterator[A] {
-      val visited = mutable.Set.empty[A] // only used if dedup enabled
-      val emitSack: mutable.Queue[A] = mutable.Queue.empty
-      worklist.addItem(WorklistItem(Traversal.fromSingle(element), 0))
-
-      def hasNext: Boolean = {
-        if (emitSack.isEmpty) {
-          // this may add elements to the emit sack and/or modify the worklist
-          traverseOnWorklist
-        }
-        emitSack.nonEmpty || worklistTopHasNext
-      }
-
-      private def traverseOnWorklist: Unit = {
-        var stop = false
-        while (worklist.nonEmpty && !stop) {
-          val WorklistItem(trav, depth) = worklist.head
-          if (trav.isEmpty) worklist.removeHead()
-          else if (behaviour.timesReached(depth)) stop = true
-          else {
-            val element = trav.next()
-            if (behaviour.dedupEnabled) visited.addOne(element)
-            if (
-              // `while/repeat` behaviour, i.e. check every time
-              behaviour.whileConditionIsDefinedAndEmpty(element) ||
-              // `repeat/until` behaviour, i.e. only check the `until` condition from depth 1
-              (depth > 0 && behaviour.untilConditionReached(element))) {
-              // we just consumed an element from the traversal, so in lieu adding to the emit sack
-              emitSack.enqueue(element)
-              stop = true
-            } else {
-              val nextLevelTraversal = {
-                val repeat = repeatTraversal(Traversal.fromSingle(element))
-                if (behaviour.dedupEnabled) repeat.filterNot(visited.contains)
-                else repeat
-              }
-              worklist.addItem(WorklistItem(nextLevelTraversal, depth + 1))
-              if (behaviour.shouldEmit(element, depth)) emitSack.enqueue(element)
-              if (emitSack.nonEmpty) stop = true
-            }
-          }
-        }
-      }
-
-      private def worklistTopHasNext: Boolean =
-        worklist.nonEmpty && worklist.head.traversal.hasNext
-
-      override def next: A = {
-        val result = {
-          if (emitSack.hasNext)
-            emitSack.dequeue()
-          else if (worklistTopHasNext)
-            worklist.head.traversal.next()
-          else throw new NoSuchElementException("next on empty iterator")
-        }
-        if (behaviour.dedupEnabled) visited.addOne(result)
-        result
-      }
-
-    })
+    *
+    * Implementation note: using recursion results in nicer code, but uses the JVM stack, which only has enough space
+    * for ~10k steps. So instead, this uses a programmatic Stack which is semantically identical.
+    * The RepeatTraversalTests cover this case.
+    * */
+  def apply[A](repeatTraversal: Traversal[A] => Traversal[A],
+               behaviour: RepeatBehaviour[A]): A => Traversal[A] = { (element: A) =>
+    Traversal(
+      new RepeatStepIterator[A](element,
+                                elem => repeatTraversal(Traversal.fromSingle(elem)).iterator,
+                                behaviour))
   }
 
   /** stores work still to do. depending on the underlying collection type, the behaviour of the repeat step changes */
   trait Worklist[A] {
-    def addItem(item: WorklistItem[A]): Unit
+    def addItem(item: A): Unit
     def nonEmpty: Boolean
-    def head: WorklistItem[A]
+    def head: A
     def removeHead(): Unit
   }
 
   /** stack based worklist for [[RepeatBehaviour.SearchAlgorithm.DepthFirst]] */
   class LifoWorklist[A] extends Worklist[A] {
-    private val stack = mutable.Stack.empty[WorklistItem[A]]
-    override def addItem(item: WorklistItem[A]) = stack.push(item)
+    private val stack = mutable.Stack.empty[A]
+    override def addItem(item: A) = stack.push(item)
     override def nonEmpty = stack.nonEmpty
     override def head = stack.top
     override def removeHead() = stack.pop()
@@ -99,12 +40,80 @@ object RepeatStep {
 
   /** queue based worklist for [[RepeatBehaviour.SearchAlgorithm.BreadthFirst]] */
   class FifoWorklist[A] extends Worklist[A] {
-    private val queue = mutable.Queue.empty[WorklistItem[A]]
-    override def addItem(item: WorklistItem[A]) = queue.enqueue(item)
+    private val queue = mutable.Queue.empty[A]
+    override def addItem(item: A) = queue.enqueue(item)
     override def nonEmpty = queue.nonEmpty
     override def head = queue.head
     override def removeHead() = queue.dequeue()
   }
 
-  case class WorklistItem[A](traversal: Traversal[A], depth: Int)
+  case class WorklistItem[A](traversal: Iterator[A], depth: Int)
+}
+
+class RepeatStepIterator[A](element: A,
+                            repeatTraversal: A => Iterator[A],
+                            behaviour: RepeatBehaviour[A])
+    extends Iterator[A] {
+  val visited = mutable.Set.empty[A] // only used if dedup enabled
+  val emitSack: mutable.Queue[A] = mutable.Queue.empty
+  val worklist: Worklist[WorklistItem[A]] = behaviour.searchAlgorithm match {
+    case SearchAlgorithm.DepthFirst   => new LifoWorklist()
+    case SearchAlgorithm.BreadthFirst => new FifoWorklist()
+  }
+
+  worklist.addItem(WorklistItem(Iterator.single(element), 0))
+
+  def hasNext: Boolean = {
+    if (emitSack.isEmpty) {
+      // this may add elements to the emit sack and/or modify the worklist
+      traverseOnWorklist
+    }
+    emitSack.nonEmpty || worklistTopHasNext
+  }
+
+  private def traverseOnWorklist: Unit = {
+    var stop = false
+    while (worklist.nonEmpty && !stop) {
+      val WorklistItem(trav, depth) = worklist.head
+      if (trav.isEmpty) worklist.removeHead()
+      else if (behaviour.timesReached(depth)) stop = true
+      else {
+        val element = trav.next()
+        if (behaviour.dedupEnabled) visited.addOne(element)
+        if (// `while/repeat` behaviour, i.e. check every time
+            behaviour.whileConditionIsDefinedAndEmpty(element) ||
+            // `repeat/until` behaviour, i.e. only check the `until` condition from depth 1
+            (depth > 0 && behaviour.untilConditionReached(element))) {
+          // we just consumed an element from the traversal, so in lieu adding to the emit sack
+          emitSack.enqueue(element)
+          stop = true
+        } else {
+          val nextLevelTraversal = {
+            val repeat = repeatTraversal(element)
+            if (behaviour.dedupEnabled) repeat.filterNot(visited.contains)
+            else repeat
+          }
+          worklist.addItem(WorklistItem(nextLevelTraversal, depth + 1))
+          if (behaviour.shouldEmit(element, depth)) emitSack.enqueue(element)
+          if (emitSack.nonEmpty) stop = true
+        }
+      }
+    }
+  }
+
+  private def worklistTopHasNext: Boolean =
+    worklist.nonEmpty && worklist.head.traversal.hasNext
+
+  override def next(): A = {
+    val result = {
+      if (emitSack.hasNext)
+        emitSack.dequeue()
+      else if (worklistTopHasNext)
+        worklist.head.traversal.next()
+      else throw new NoSuchElementException("next on empty iterator")
+    }
+    if (behaviour.dedupEnabled) visited.addOne(result)
+    result
+  }
+
 }


### PR DESCRIPTION
Factored out the iterator class used in RepeatStep and made it
independent of Traversal class.
Furthermore i moved the work list creation into the iterator class to
make sure that no funny stuff can happen because of the shared work
list. The way it is currently used works but if the generated traversals
are not completely drained before the next traversal is created and
used, the work items get mixed up.

I piggy bagged changes to make RepeatBehaviour independent from Traversal and cleanup for the RepeatBehaviour Builder.