### PR TITLE
Executor service configuration.

### DIFF
--- a/core/src/main/java/overflowdb/Config.java
+++ b/core/src/main/java/overflowdb/Config.java
@@ -3,12 +3,14 @@ package overflowdb;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 public class Config {
   private boolean overflowEnabled = true;
   private int heapPercentageThreshold = 80;
   private Optional<Path> storageLocation = Optional.empty();
   private boolean serializationStatsEnabled = false;
+  private Optional<ExecutorService> executorService = Optional.empty();
 
   public static Config withDefaults() {
     return new Config();
@@ -64,5 +66,14 @@ public class Config {
 
   public boolean isSerializationStatsEnabled() {
     return serializationStatsEnabled;
+  }
+
+  public Config withExecutorService(ExecutorService executorService) {
+    this.executorService = Optional.ofNullable(executorService);
+    return this;
+  }
+
+  public Optional<ExecutorService> getExecutorService() {
+    return executorService;
   }
 }

--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -77,7 +77,11 @@ public final class Graph implements AutoCloseable {
 
     this.overflowEnabled = config.isOverflowEnabled();
     if (this.overflowEnabled) {
-      this.referenceManager = new ReferenceManager(storage, nodesWriter);
+      if (config.getExecutorService().isPresent()) {
+        this.referenceManager = new ReferenceManager(storage, nodesWriter, config.getExecutorService().get());
+      } else {
+        this.referenceManager = new ReferenceManager(storage, nodesWriter);
+      }
       this.heapUsageMonitor = Optional.of(new HeapUsageMonitor(config.getHeapPercentageThreshold(), this.referenceManager));
     } else {
       this.referenceManager = null; // not using Optional only due to performance reasons - it's invoked *a lot*

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -3,7 +3,6 @@ package overflowdb;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 

--- a/core/src/main/java/overflowdb/ReferenceManager.java
+++ b/core/src/main/java/overflowdb/ReferenceManager.java
@@ -38,14 +38,14 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
     this.storage = storage;
     this.nodesWriter = nodesWriter;
     this.executorService = Executors.newSingleThreadExecutor(new NamedThreadFactory("overflowdb-reference-manager"));
-    this.shouldShutdown = false;
+    this.shouldShutdown = true;
   }
 
   public ReferenceManager(OdbStorage storage, NodesWriter nodesWriter, ExecutorService executorService) {
     this.storage = storage;
     this.nodesWriter = nodesWriter;
     this.executorService = executorService;
-    this.shouldShutdown = true;
+    this.shouldShutdown = false;
   }
 
   /* Register NodeRef, so it can be cleared on low memory */

--- a/core/src/main/java/overflowdb/ReferenceManager.java
+++ b/core/src/main/java/overflowdb/ReferenceManager.java
@@ -8,13 +8,10 @@ import overflowdb.util.NamedThreadFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 /**
  * can clear references to disk and apply backpressure when creating new nodes, both to avoid an OutOfMemoryError

--- a/core/src/main/java/overflowdb/ReferenceManager.java
+++ b/core/src/main/java/overflowdb/ReferenceManager.java
@@ -27,25 +27,35 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
   public final int releaseCount = 100000;
   private AtomicInteger totalReleaseCount = new AtomicInteger(0);
   private final ExecutorService executorService;
-  private final boolean shouldShutdown;
+  private final boolean shutdownExecutorOnClose;
   private int clearingProcessCount = 0;
   private final Object backPressureSyncObject = new Object();
   private final OdbStorage storage;
   private final NodesWriter nodesWriter;
   private final List<NodeRef> clearableRefs = Collections.synchronizedList(new ArrayList<>());
 
+  /**
+   * Create a reference manager with the given storage and node writer set; also spawns and manages
+   * a background thread for clearing references - if you'd like more control consider using
+   * {@link #ReferenceManager(OdbStorage, NodesWriter, ExecutorService)} instead.
+   */
   public ReferenceManager(OdbStorage storage, NodesWriter nodesWriter) {
     this.storage = storage;
     this.nodesWriter = nodesWriter;
     this.executorService = Executors.newSingleThreadExecutor(new NamedThreadFactory("overflowdb-reference-manager"));
-    this.shouldShutdown = true;
+    this.shutdownExecutorOnClose = true;
   }
 
+  /**
+   * Create a reference manager with the given storage and node writer set; the given executor will be used to spawn
+   * a background thread for clearing references.  Note that the executor will not be shut down once {@link #close()}
+   * is called, it's the callers responsibility to manage it.
+   */
   public ReferenceManager(OdbStorage storage, NodesWriter nodesWriter, ExecutorService executorService) {
     this.storage = storage;
     this.nodesWriter = nodesWriter;
     this.executorService = executorService;
-    this.shouldShutdown = false;
+    this.shutdownExecutorOnClose = false;
   }
 
   /* Register NodeRef, so it can be cleared on low memory */
@@ -148,7 +158,7 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
 
   @Override
   public void close() {
-    if (shouldShutdown) {
+    if (shutdownExecutorOnClose) {
       executorService.shutdown();
     }
   }

--- a/core/src/main/java/overflowdb/storage/NodeDeserializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeDeserializer.java
@@ -3,7 +3,6 @@ package overflowdb.storage;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessageUnpacker;
 import org.msgpack.value.ArrayValue;
-import org.msgpack.value.ImmutableArrayValue;
 import org.msgpack.value.ImmutableValue;
 import org.msgpack.value.Value;
 import overflowdb.Direction;

--- a/core/src/main/java/overflowdb/storage/NodesWriter.java
+++ b/core/src/main/java/overflowdb/storage/NodesWriter.java
@@ -7,7 +7,6 @@ import overflowdb.NodeDb;
 import overflowdb.NodeRef;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.StreamSupport;


### PR DESCRIPTION
Going forward, we'd like to set the executor from the outside, for, amongst other things, being able to correctly configure the logging context being used.