### PR TITLE
Use stripMargin on @Doc longInfo and example.

### DIFF
--- a/traversal/src/main/java/overflowdb/traversal/help/Doc.java
+++ b/traversal/src/main/java/overflowdb/traversal/help/Doc.java
@@ -7,11 +7,11 @@ import java.lang.annotation.RetentionPolicy;
   * Annotation used for documentation.
   *
   * @param info a one line description for the overview table
-  * @param longInfo in-depth documentation processed by Scalas .stripMargin to
-  *                 allow for convienied multiline string writing with "|".
-  * @param example a short example for the overview table processed by Scalas
-  *                  .stripMargin to allow for convienied multiline string
-  *                  writing with "|".
+  * @param longInfo in-depth documentation
+  * @param example a short example for the overview table
+  * note: both longInfo and example are processed by Scala's `.stripMargin` to
+  *       allow for convenient multiline string writing with "|".
+  *       see https://docs.scala-lang.org/scala3/book/first-look-at-types.html#multiline-strings
   * */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Doc {

--- a/traversal/src/main/java/overflowdb/traversal/help/Doc.java
+++ b/traversal/src/main/java/overflowdb/traversal/help/Doc.java
@@ -3,6 +3,16 @@ package overflowdb.traversal.help;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+/**
+  * Annotation used for documentation.
+  *
+  * @param info a one line description for the overview table
+  * @param longInfo in-depth documentation processed by Scalas .stripMargin to
+  *                 allow for convienied multiline string writing with "|".
+  * @param example a short example for the overview table processed by Scalas
+  *                  .stripMargin to allow for convienied multiline string
+  *                  writing with "|".
+  * */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Doc {
   String info();

--- a/traversal/src/main/scala/overflowdb/traversal/help/TraversalHelp.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/help/TraversalHelp.scala
@@ -91,9 +91,7 @@ class TraversalHelp(domainBasePackage: String) {
     traversal.getMethods.flatMap { method =>
       method.getAnnotations.find(_.isInstanceOf[Doc]).map { case docAnnotation: Doc =>
         StepDoc(traversal.getName, method.getName,
-          StrippedDoc(docAnnotation.info,
-            docAnnotation.longInfo.stripMargin,
-            docAnnotation.example.stripMargin)
+          StrippedDoc(docAnnotation.info, docAnnotation.longInfo.stripMargin, docAnnotation.example.stripMargin)
         )
       }
     }

--- a/traversal/src/main/scala/overflowdb/traversal/help/TraversalHelp.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/help/TraversalHelp.scala
@@ -90,10 +90,15 @@ class TraversalHelp(domainBasePackage: String) {
   protected def findStepDocs(traversal: Class[_]): Iterable[StepDoc] = {
     traversal.getMethods.flatMap { method =>
       method.getAnnotations.find(_.isInstanceOf[Doc]).map { case docAnnotation: Doc =>
-        StepDoc(traversal.getName, method.getName, docAnnotation)
+        StepDoc(traversal.getName, method.getName,
+          StrippedDoc(docAnnotation.info,
+            docAnnotation.longInfo.stripMargin,
+            docAnnotation.example.stripMargin)
+        )
       }
     }
   }
 
-  case class StepDoc(traversalClassName: String, methodName: String, doc: Doc)
+  case class StepDoc(traversalClassName: String, methodName: String, doc: StrippedDoc)
+  case class StrippedDoc(info: String, longInfo: String, example: String)
 }


### PR DESCRIPTION
We do this to remedy the fact that we cannot use stripMargin on the
arguments of @Doc because it is now a Java annotation.