### PR TITLE
Add toSetMutable end step to Traversal.

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -30,6 +30,9 @@ class Traversal[A](elements: IterableOnce[A])
   /** Execute the traversal and return a mutable.Set (better performance than `immutableSet`) */
   def toSet: mutable.Set[A] = mutable.Set.from(this)
 
+ /** Execute the traversal and return a mutable.Set (better performance than `immutableSet`) */
+  def toSetMutable: mutable.Set[A] = mutable.Set.from(this)
+
   /** Execute the traversal and convert the result to an immutable Set */
   def toSetImmutable: Set[A] = iterator.toSet
 

--- a/traversal/src/test/scala/overflowdb/GraphSugarTests.scala
+++ b/traversal/src/test/scala/overflowdb/GraphSugarTests.scala
@@ -33,7 +33,7 @@ class GraphSugarTests extends AnyWordSpec {
       val graph = SimpleDomain.newGraph
       graph + (Thing.Label, Name -> "one thing")
       graph + (Thing.Label, Name -> "another thing", Size -> 42)
-      SimpleDomain.traversal(graph).things.propertiesMap.toSet shouldBe Set(
+      SimpleDomain.traversal(graph).things.propertiesMap.toSetMutable shouldBe Set(
         Map(("name", "one thing")),
         Map(("name", "another thing"), ("size", 42))
       )
@@ -94,7 +94,7 @@ class GraphSugarTests extends AnyWordSpec {
       node1 --- (Connection.Label, Distance.of(30), Name.of("Alternative")) --> node2
 
       node1.out(Connection.Label).toList shouldBe List(node2, node2)
-      node1.outE(Connection.Label).propertiesMap.toSet shouldBe Set(
+      node1.outE(Connection.Label).propertiesMap.toSetMutable shouldBe Set(
         Map(("distance", 10)),
         Map(("distance", 30), ("name", "Alternative"))
       )

--- a/traversal/src/test/scala/overflowdb/traversal/GenericGraphTraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/GenericGraphTraversalTests.scala
@@ -28,9 +28,9 @@ class GenericGraphTraversalTests extends AnyWordSpec {
   }
 
   "property lookup" in {
-    graph.V.property(Name).toSet shouldBe Set("L3", "L2", "L1", "Center", "R1", "R2", "R3", "R4", "R5")
-    graph.E.property(Distance).toSet shouldBe Set(10, 13, 14)
-    graph.E.propertyOption(Distance).toSet shouldBe Set(Some(10), Some(13), Some(14), None)
+    graph.V.property(Name).toSetMutable shouldBe Set("L3", "L2", "L1", "Center", "R1", "R2", "R3", "R4", "R5")
+    graph.E.property(Distance).toSetMutable shouldBe Set(10, 13, 14)
+    graph.E.propertyOption(Distance).toSetMutable shouldBe Set(Some(10), Some(13), Some(14), None)
   }
 
   "filter steps" can {
@@ -89,61 +89,61 @@ class GenericGraphTraversalTests extends AnyWordSpec {
 
     "`where` step taking a traversal" in {
       // find all nodes that _do_ have an OUT neighbor, i.e. find the inner nodes
-      graph.V.where(_.out).property(Name).toSet shouldBe Set("L2", "L1", "Center", "R1", "R2", "R3", "R4")
+      graph.V.where(_.out).property(Name).toSetMutable shouldBe Set("L2", "L1", "Center", "R1", "R2", "R3", "R4")
     }
 
     "`not` step taking a traversal" in {
       // find all nodes that do _not_ have an OUT neighbor, i.e. find the outermost nodes
-       graph.V.not(_.out).property(Name).toSet shouldBe Set("L3", "R5")
+       graph.V.not(_.out).property(Name).toSetMutable shouldBe Set("L3", "R5")
     }
   }
 
   "base steps: out/in/both" can {
     "step out" in {
-      center.start.out.toSet shouldBe Set(l1, r1)
-      center.start.out.out.toSet shouldBe Set(l2, r2)
-      center.start.out(Connection.Label).toSet shouldBe Set(l1, r1)
-      center.start.out(nonExistingLabel, Connection.Label).toSet shouldBe Set(l1, r1)
-      center.start.out(nonExistingLabel).toSet shouldBe Set.empty
+      center.start.out.toSetMutable shouldBe Set(l1, r1)
+      center.start.out.out.toSetMutable shouldBe Set(l2, r2)
+      center.start.out(Connection.Label).toSetMutable shouldBe Set(l1, r1)
+      center.start.out(nonExistingLabel, Connection.Label).toSetMutable shouldBe Set(l1, r1)
+      center.start.out(nonExistingLabel).toSetMutable shouldBe Set.empty
     }
 
     "step in" in {
       l2.start.in.size shouldBe 1
-      l2.start.in.toSet shouldBe Set(l1)
-      l2.start.in.in.toSet shouldBe Set(center)
-      l2.start.in(Connection.Label).toSet shouldBe Set(l1)
-      l2.start.in(nonExistingLabel, Connection.Label).toSet shouldBe Set(l1)
-      l2.start.in(nonExistingLabel).toSet shouldBe Set.empty
+      l2.start.in.toSetMutable shouldBe Set(l1)
+      l2.start.in.in.toSetMutable shouldBe Set(center)
+      l2.start.in(Connection.Label).toSetMutable shouldBe Set(l1)
+      l2.start.in(nonExistingLabel, Connection.Label).toSetMutable shouldBe Set(l1)
+      l2.start.in(nonExistingLabel).toSetMutable shouldBe Set.empty
     }
 
     "step both" in {
       /* L3 <- L2 <- L1 <- Center -> R1 -> R2 -> R3 -> R4 */
       l2.start.both.size shouldBe 2
-      l2.start.both.toSet shouldBe Set(l1, l3)
-      r2.start.both.toSet shouldBe Set(r1, r3)
-      l2.start.both.both.toSet shouldBe Set(l2, center)
-      r2.start.both.both.toSet shouldBe Set(center, r2, r4)
-      l2.start.both(Connection.Label).toSet shouldBe Set(l1, l3)
-      l2.start.both(nonExistingLabel, Connection.Label).toSet shouldBe Set(l1, l3)
-      l2.start.both(nonExistingLabel).toSet shouldBe Set.empty
+      l2.start.both.toSetMutable shouldBe Set(l1, l3)
+      r2.start.both.toSetMutable shouldBe Set(r1, r3)
+      l2.start.both.both.toSetMutable shouldBe Set(l2, center)
+      r2.start.both.both.toSetMutable shouldBe Set(center, r2, r4)
+      l2.start.both(Connection.Label).toSetMutable shouldBe Set(l1, l3)
+      l2.start.both(nonExistingLabel, Connection.Label).toSetMutable shouldBe Set(l1, l3)
+      l2.start.both(nonExistingLabel).toSetMutable shouldBe Set.empty
     }
 
     "step outE" in {
       center.start.outE.size shouldBe 2
-      center.start.outE.inV.toSet shouldBe Set(l1, r1)
-      center.start.outE.inV.outE.inV.toSet shouldBe Set(l2, r2)
-      center.start.outE(Connection.Label).inV.toSet shouldBe Set(l1, r1)
-      center.start.outE(nonExistingLabel, Connection.Label).inV.toSet shouldBe Set(l1, r1)
-      center.start.outE(nonExistingLabel).inV.toSet shouldBe Set.empty
+      center.start.outE.inV.toSetMutable shouldBe Set(l1, r1)
+      center.start.outE.inV.outE.inV.toSetMutable shouldBe Set(l2, r2)
+      center.start.outE(Connection.Label).inV.toSetMutable shouldBe Set(l1, r1)
+      center.start.outE(nonExistingLabel, Connection.Label).inV.toSetMutable shouldBe Set(l1, r1)
+      center.start.outE(nonExistingLabel).inV.toSetMutable shouldBe Set.empty
     }
 
     "step inE" in {
       l2.start.inE.size shouldBe 1
-      l2.start.inE.outV.toSet shouldBe Set(l1)
-      l2.start.inE.outV.inE.outV.toSet shouldBe Set(center)
-      l2.start.inE(Connection.Label).outV.toSet shouldBe Set(l1)
-      l2.start.inE(nonExistingLabel, Connection.Label).outV.toSet shouldBe Set(l1)
-      l2.start.inE(nonExistingLabel).outV.toSet shouldBe Set.empty
+      l2.start.inE.outV.toSetMutable shouldBe Set(l1)
+      l2.start.inE.outV.inE.outV.toSetMutable shouldBe Set(center)
+      l2.start.inE(Connection.Label).outV.toSetMutable shouldBe Set(l1)
+      l2.start.inE(nonExistingLabel, Connection.Label).outV.toSetMutable shouldBe Set(l1)
+      l2.start.inE(nonExistingLabel).outV.toSetMutable shouldBe Set.empty
     }
 
     "step bothE" in {

--- a/traversal/src/test/scala/overflowdb/traversal/GratefulDeadTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/GratefulDeadTests.scala
@@ -13,12 +13,12 @@ class GratefulDeadTests extends AnyWordSpec {
     "perform generic graph steps" in {
       gratefulDead.all.size shouldBe 808
       gratefulDead.all.id.l.sorted.head shouldBe 1
-      gratefulDead.all.label.toSet shouldBe Set(Artist.Label, Song.Label)
+      gratefulDead.all.label.toSetMutable shouldBe Set(Artist.Label, Song.Label)
 
       gratefulDead.label(Artist.Label).size shouldBe 224
       gratefulDead.id(1).label.head shouldBe Song.Label
       gratefulDead.id(2).property(Song.Properties.Name).head shouldBe "IM A MAN"
-      gratefulDead.ids(3, 4).property[String]("name").toSet shouldBe Set("BERTHA", "NOT FADE AWAY")
+      gratefulDead.ids(3, 4).property[String]("name").toSetMutable shouldBe Set("BERTHA", "NOT FADE AWAY")
       gratefulDead.all.has(Song.Properties.SongType).size shouldBe 584
       gratefulDead.all.has(Song.Properties.Performances, 2).size shouldBe 36
     }
@@ -64,7 +64,7 @@ class GratefulDeadTests extends AnyWordSpec {
     "traverse domain-specific edges" in {
       gratefulDead.artists.nameExact("Bob_Dylan").sangSongs.size shouldBe 22
       gratefulDead.songs.nameExact("WALKIN THE DOG").followedBy.size shouldBe 5
-      gratefulDead.songs.nameExact("WALKIN THE DOG").followedBy.songType.toSet shouldBe Set("original", "cover", "")
+      gratefulDead.songs.nameExact("WALKIN THE DOG").followedBy.songType.toSetMutable shouldBe Set("original", "cover", "")
     }
 
     "be expressed in for comprehension" in {
@@ -102,7 +102,7 @@ class GratefulDeadTests extends AnyWordSpec {
         .sangSongs
         .repeat(_.followedBy)(_.times(3))
         .sungBy
-        .toSet
+        .toSetMutable
         .size shouldBe 43
     }
   }

--- a/traversal/src/test/scala/overflowdb/traversal/LogicalStepsTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/LogicalStepsTests.scala
@@ -42,7 +42,7 @@ class LogicalStepsTests extends AnyWordSpec {
       graph.nodes(Thing.Label)
         .choose(_.property(Name)) {
           case "L1" => _.out // -> L2
-        }.property(Name).toSet shouldBe Set("L2")
+        }.property(Name).toSetMutable shouldBe Set("L2")
     }
 
     "provide if/elseif semantics" in {
@@ -50,7 +50,7 @@ class LogicalStepsTests extends AnyWordSpec {
         .choose(_.property(Name)) {
           case "L1" => _.out // -> L2
           case "R1" => _.repeat(_.out)(_.times(3)) // -> R4
-        }.property(Name).toSet shouldBe Set("L2", "R4")
+        }.property(Name).toSetMutable shouldBe Set("L2", "R4")
     }
 
     "provide if/else semantics" in {
@@ -59,7 +59,7 @@ class LogicalStepsTests extends AnyWordSpec {
           case "L1" => _.out // -> L2
           case "R1" => _.repeat(_.out)(_.times(3)) // -> R4
           case _ => _.in
-        }.property(Name).toSet shouldBe Set("L2", "L1", "R1", "R2", "R3", "R4")
+        }.property(Name).toSetMutable shouldBe Set("L2", "L1", "R1", "R2", "R3", "R4")
     }
 
     "handle empty `on` traversal: if semantics" in {
@@ -74,12 +74,12 @@ class LogicalStepsTests extends AnyWordSpec {
         .choose(_.property(Name).filter(_ => false)) {
           case "L1" => _.in
           case _ => _.out
-        }.property(Name).toSet shouldBe Set("L3", "L2", "L1", "R1", "R2", "R3", "R4", "R5")
+        }.property(Name).toSetMutable shouldBe Set("L3", "L2", "L1", "R1", "R2", "R3", "R4", "R5")
     }
   }
 
   "coalesce step takes arbitrary number of traversals and follows the first one that returns at least one element" in {
-    centerTrav.coalesce(_.out).property(Name).toSet shouldBe Set("L1", "R1")
+    centerTrav.coalesce(_.out).property(Name).toSetMutable shouldBe Set("L1", "R1")
 
     centerTrav.coalesce().size shouldBe 0
     centerTrav.coalesce(_.out("doesn't exist")).size shouldBe 0
@@ -90,17 +90,17 @@ class LogicalStepsTests extends AnyWordSpec {
       _.out("doesn't exist"),
       _.out,
       _.sideEffect(_ => thirdTraversalInvoked = true).out
-    ).property(Name).toSet shouldBe Set("L1", "R1")
+    ).property(Name).toSetMutable shouldBe Set("L1", "R1")
     thirdTraversalInvoked shouldBe false
 
     centerTrav.coalesce(
       _.name("doesn't exist"),
       _.followedBy
-    ).name.toSet shouldBe Set("L1", "R1")
+    ).name.toSetMutable shouldBe Set("L1", "R1")
 
     // we can even mix generic graph steps (.out) and domain-specific steps (.followedBy), but need to help the type
     // inferencer by specifying `[Node]` as the result type
-    centerTrav.coalesce[Node](_.out, _.followedBy).property(Name).toSet shouldBe Set("L1", "R1")
+    centerTrav.coalesce[Node](_.out, _.followedBy).property(Name).toSetMutable shouldBe Set("L1", "R1")
   }
 
 }

--- a/traversal/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -18,59 +18,59 @@ class PathTraversalTests extends AnyWordSpec {
     }
 
     "work for single element traversal (boring)" in {
-      centerTrav.enablePathTracking.path.toSet shouldBe Set(Seq(center))
+      centerTrav.enablePathTracking.path.toSetMutable shouldBe Set(Seq(center))
     }
 
     "work for simple one-step expansion" in {
-      centerTrav.enablePathTracking.out.path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.out.path.toSetMutable shouldBe Set(
         Seq(center, l1),
         Seq(center, r1))
     }
 
     "work for simple two-step expansion" in {
-      centerTrav.enablePathTracking.out.out.path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.out.out.path.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2))
     }
 
     "only track from where it's enabled" in {
-      centerTrav.out.enablePathTracking.out.path.toSet shouldBe Set(
+      centerTrav.out.enablePathTracking.out.path.toSetMutable shouldBe Set(
         Seq(l1, l2),
         Seq(r1, r2))
     }
 
     "support domain-specific steps" in {
-      centerTrav.enablePathTracking.followedBy.followedBy.path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.followedBy.followedBy.path.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2))
     }
 
     "work in combination with other steps" should {
       ".map: include intermediate results in path" in {
-        centerTrav.enablePathTracking.followedBy.map(_.name).path.toSet shouldBe Set(
+        centerTrav.enablePathTracking.followedBy.map(_.name).path.toSetMutable shouldBe Set(
           Seq(center, l1, "L1"),
           Seq(center, r1, "R1"))
       }
 
       "collect: include intermediate results in path" in {
-        centerTrav.enablePathTracking.followedBy.collect { case x => x.name }.path.toSet shouldBe Set(
+        centerTrav.enablePathTracking.followedBy.collect { case x => x.name }.path.toSetMutable shouldBe Set(
           Seq(center, l1, "L1"),
           Seq(center, r1, "R1"))
       }
 
       "filter" in {
-        centerTrav.enablePathTracking.followedBy.nameStartsWith("R").followedBy.path.toSet shouldBe Set(
+        centerTrav.enablePathTracking.followedBy.nameStartsWith("R").followedBy.path.toSetMutable shouldBe Set(
           Seq(center, r1, r2))
       }
 
       "filterNot" in {
-        centerTrav.enablePathTracking.followedBy.filterNot(_.name.startsWith("R")).followedBy.path.toSet shouldBe Set(
+        centerTrav.enablePathTracking.followedBy.filterNot(_.name.startsWith("R")).followedBy.path.toSetMutable shouldBe Set(
           Seq(center, l1, l2))
       }
 
       "dedup" in {
-        verifyResults(center.start.enablePathTracking.both.both.dedup.path.toSet)
-        verifyResults(center.start.enablePathTracking.both.both.dedupBy(_.hashCode).path.toSet)
+        verifyResults(center.start.enablePathTracking.both.both.dedup.path.toSetMutable)
+        verifyResults(center.start.enablePathTracking.both.both.dedupBy(_.hashCode).path.toSetMutable)
 
         def verifyResults(paths: collection.Set[Vector[_]]) = {
           paths should contain(Vector(center, l1, l2))
@@ -92,18 +92,18 @@ class PathTraversalTests extends AnyWordSpec {
       }
 
       "where" in {
-        centerTrav.enablePathTracking.followedBy.where(_.nameStartsWith("R")).followedBy.path.toSet shouldBe Set(
+        centerTrav.enablePathTracking.followedBy.where(_.nameStartsWith("R")).followedBy.path.toSetMutable shouldBe Set(
           Seq(center, r1, r2))
       }
 
       "whereNot" in {
-        centerTrav.enablePathTracking.followedBy.whereNot(_.nameStartsWith("R")).followedBy.path.toSet shouldBe Set(
+        centerTrav.enablePathTracking.followedBy.whereNot(_.nameStartsWith("R")).followedBy.path.toSetMutable shouldBe Set(
           Seq(center, l1, l2))
       }
 
       "sideEffect" in {
         val sack = mutable.ListBuffer.empty[Node]
-        center.start.enablePathTracking.out.sideEffect(sack.addOne).out.path.toSet shouldBe Set(
+        center.start.enablePathTracking.out.sideEffect(sack.addOne).out.path.toSetMutable shouldBe Set(
           Seq(center, l1, l2),
           Seq(center, r1, r2),
         )
@@ -123,7 +123,7 @@ class PathTraversalTests extends AnyWordSpec {
           }
           .out
           .path
-          .toSet shouldBe Set(
+          .toSetMutable shouldBe Set(
           Seq(center, l1, l2),
           Seq(center, r1, r2)
         )
@@ -154,7 +154,7 @@ class PathTraversalTests extends AnyWordSpec {
           .choose(_.property(Name)) {
             case "L1" => _.out // -> L2
             case "R1" => _.repeat(_.out)(_.times(3)) // -> R4
-          }.property(Name).path.toSet shouldBe Set(
+          }.property(Name).path.toSetMutable shouldBe Set(
           Seq(r1, r4, "R4"),
           Seq(l1, l2, "L2")
         )
@@ -166,7 +166,7 @@ class PathTraversalTests extends AnyWordSpec {
           _.out("doesn't exist"),
           _.out,
           _.sideEffect(_ => traversalInvoked = true).out
-        ).property(Name).path.toSet shouldBe Set(
+        ).property(Name).path.toSetMutable shouldBe Set(
           Seq(center, l1, "L1"),
           Seq(center, r1, "R1"),
         )
@@ -178,9 +178,9 @@ class PathTraversalTests extends AnyWordSpec {
 
   ".simplePath step" should {
     "remove results where path has repeated objects on the path" in {
-      center.start.enablePathTracking.both.both.simplePath.toSet shouldBe Set(l2, r2)
+      center.start.enablePathTracking.both.both.simplePath.toSetMutable shouldBe Set(l2, r2)
 
-      center.start.enablePathTracking.both.both.simplePath.path.toSet shouldBe Set(
+      center.start.enablePathTracking.both.both.simplePath.path.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2),
       )

--- a/traversal/src/test/scala/overflowdb/traversal/RepeatTraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/RepeatTraversalTests.scala
@@ -17,61 +17,61 @@ class RepeatTraversalTests extends AnyWordSpec {
    */
 
   "typical case for both domain-specific steps" in {
-    centerTrav.repeat(_.followedBy)(_.times(2)).name.toSet shouldBe Set("L2", "R2")
+    centerTrav.repeat(_.followedBy)(_.times(2)).name.toSetMutable shouldBe Set("L2", "R2")
   }
 
   "typical case for both generic graph steps" in {
-    centerTrav.repeat(_.out)(_.times(2)).property(Name).toSet shouldBe Set("L2", "R2")
+    centerTrav.repeat(_.out)(_.times(2)).property(Name).toSetMutable shouldBe Set("L2", "R2")
   }
 
   "repeat given traversal X times" should {
     "return only the final elements" in {
       val expectedResults = Set("L2", "R2")
-      centerTrav.repeat(_.followedBy)(_.times(2)).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.followedBy)(_.times(2).breadthFirstSearch).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.times(2)).property(Name).toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.times(2).breadthFirstSearch).property(Name).toSet shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.times(2)).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.times(2).breadthFirstSearch).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.times(2)).property(Name).toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.times(2).breadthFirstSearch).property(Name).toSetMutable shouldBe expectedResults
     }
 
     "return only the final elements - if any" in {
       val expectedResults = Set("R4") // there is no L4
-      centerTrav.repeat(_.followedBy)(_.times(4)).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.followedBy)(_.times(4).breadthFirstSearch).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.times(4)).property(Name).toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.times(4).breadthFirstSearch).property(Name).toSet shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.times(4)).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.times(4).breadthFirstSearch).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.times(4)).property(Name).toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.times(4).breadthFirstSearch).property(Name).toSetMutable shouldBe expectedResults
     }
 
     "return everything along the way also, if used in combination with emit" in {
       val expectedResults = Set("Center", "L1", "L2", "R1", "R2")
-      centerTrav.repeat(_.followedBy)(_.times(2).emit).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.followedBy)(_.times(2).emit.breadthFirstSearch).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.times(2).emit).property(Name).toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.times(2).emit.breadthFirstSearch).property(Name).toSet shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.times(2).emit).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.times(2).emit.breadthFirstSearch).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.times(2).emit).property(Name).toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.times(2).emit.breadthFirstSearch).property(Name).toSetMutable shouldBe expectedResults
     }
   }
 
   "emit everything along the way if so configured" in {
     val expectedResults = Set("L3", "L2", "L1", "Center", "R1", "R2", "R3", "R4", "R5")
-    centerTrav.repeat(_.followedBy)(_.emit).name.toSet shouldBe expectedResults
-    centerTrav.repeat(_.followedBy)(_.emit.breadthFirstSearch).name.toSet shouldBe expectedResults
-    centerTrav.repeat(_.out)(_.emit).property("name").toSet shouldBe expectedResults
-    centerTrav.repeat(_.out)(_.emit.breadthFirstSearch).property("name").toSet shouldBe expectedResults
+    centerTrav.repeat(_.followedBy)(_.emit).name.toSetMutable shouldBe expectedResults
+    centerTrav.repeat(_.followedBy)(_.emit.breadthFirstSearch).name.toSetMutable shouldBe expectedResults
+    centerTrav.repeat(_.out)(_.emit).property("name").toSetMutable shouldBe expectedResults
+    centerTrav.repeat(_.out)(_.emit.breadthFirstSearch).property("name").toSetMutable shouldBe expectedResults
   }
 
   "emit everything but the first element (starting point)" in {
     val expectedResults = Set("L3", "L2", "L1", "R1", "R2", "R3", "R4", "R5")
-    centerTrav.repeat(_.followedBy)(_.emitAllButFirst).name.toSet shouldBe expectedResults
-    centerTrav.repeat(_.followedBy)(_.emitAllButFirst.breadthFirstSearch).name.toSet shouldBe expectedResults
-    centerTrav.repeat(_.out)(_.emitAllButFirst).property("name").toSet shouldBe expectedResults
-    centerTrav.repeat(_.out)(_.emitAllButFirst.breadthFirstSearch).property("name").toSet shouldBe expectedResults
+    centerTrav.repeat(_.followedBy)(_.emitAllButFirst).name.toSetMutable shouldBe expectedResults
+    centerTrav.repeat(_.followedBy)(_.emitAllButFirst.breadthFirstSearch).name.toSetMutable shouldBe expectedResults
+    centerTrav.repeat(_.out)(_.emitAllButFirst).property("name").toSetMutable shouldBe expectedResults
+    centerTrav.repeat(_.out)(_.emitAllButFirst.breadthFirstSearch).property("name").toSetMutable shouldBe expectedResults
   }
 
   "emit nodes that meet given condition" in {
     val expectedResults = Set("L1", "L2", "L3")
-    centerTrav.repeat(_.followedBy)(_.emit(_.name.filter(_.startsWith("L")))).name.toSet shouldBe expectedResults
-    centerTrav.repeat(_.followedBy)(_.emit(_.name.filter(_.startsWith("L"))).breadthFirstSearch).name.toSet shouldBe expectedResults
-    centerTrav.repeat(_.out)(_.emit(_.has(Name.where(_.startsWith("L"))))).property(Name).toSet shouldBe expectedResults
-    centerTrav.repeat(_.out)(_.emit(_.has(Name.where(_.startsWith("L")))).breadthFirstSearch).property(Name).toSet shouldBe expectedResults
+    centerTrav.repeat(_.followedBy)(_.emit(_.name.filter(_.startsWith("L")))).name.toSetMutable shouldBe expectedResults
+    centerTrav.repeat(_.followedBy)(_.emit(_.name.filter(_.startsWith("L"))).breadthFirstSearch).name.toSetMutable shouldBe expectedResults
+    centerTrav.repeat(_.out)(_.emit(_.has(Name.where(_.startsWith("L"))))).property(Name).toSetMutable shouldBe expectedResults
+    centerTrav.repeat(_.out)(_.emit(_.has(Name.where(_.startsWith("L")))).breadthFirstSearch).property(Name).toSetMutable shouldBe expectedResults
   }
 
   "going through multiple steps in repeat traversal" in {
@@ -86,65 +86,65 @@ class RepeatTraversalTests extends AnyWordSpec {
   "support arbitrary `until` condition" should {
     "work without emit" in {
       val expectedResults = Set("L2", "R2")
-      centerTrav.repeat(_.followedBy)(_.until(_.name.filter(_.endsWith("2")))).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.followedBy)(_.until(_.name.filter(_.endsWith("2"))).breadthFirstSearch).name.toSet shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.until(_.name.filter(_.endsWith("2")))).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.until(_.name.filter(_.endsWith("2"))).breadthFirstSearch).name.toSetMutable shouldBe expectedResults
 
       centerTrav.repeat(_.out)(
         _.until(_.has(Name.where(_.matches(".*2")))))
-        .property(Name).toSet shouldBe expectedResults
+        .property(Name).toSetMutable shouldBe expectedResults
 
       centerTrav.repeat(_.out)(
         _.until(_.has(Name.where(_.matches(".*2")))).breadthFirstSearch)
-        .property(Name).toSet shouldBe expectedResults
+        .property(Name).toSetMutable shouldBe expectedResults
     }
 
     "work in combination with emit" in {
       val expectedResults = Set("Center", "L1", "L2", "R1", "R2")
-      centerTrav.repeat(_.followedBy)(_.until(_.name.filter(_.endsWith("2"))).emit).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.followedBy)(_.until(_.name.filter(_.endsWith("2"))).emit.breadthFirstSearch).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.until(_.has(Name.where(_.matches(".*2")))).emit).property(Name).toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.until(_.has(Name.where(_.matches(".*2")))).emit.breadthFirstSearch).property(Name).toSet shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.until(_.name.filter(_.endsWith("2"))).emit).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.until(_.name.filter(_.endsWith("2"))).emit.breadthFirstSearch).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.until(_.has(Name.where(_.matches(".*2")))).emit).property(Name).toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.until(_.has(Name.where(_.matches(".*2")))).emit.breadthFirstSearch).property(Name).toSetMutable shouldBe expectedResults
     }
 
     "result in 'repeat/until' behaviour, i.e. `until` condition is only evaluated after one iteration" in {
       val expectedResults = Set("L1", "R1")
-      centerTrav.repeat(_.followedBy)(_.until(_.filter(_.label == Thing.Label))).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.followedBy)(_.until(_.filter(_.label == Thing.Label)).breadthFirstSearch).name.toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.until(_.hasLabel(Thing.Label))).property(Name).toSet shouldBe expectedResults
-      centerTrav.repeat(_.out)(_.until(_.hasLabel(Thing.Label)).breadthFirstSearch).property(Name).toSet shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.until(_.filter(_.label == Thing.Label))).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.followedBy)(_.until(_.filter(_.label == Thing.Label)).breadthFirstSearch).name.toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.until(_.hasLabel(Thing.Label))).property(Name).toSetMutable shouldBe expectedResults
+      centerTrav.repeat(_.out)(_.until(_.hasLabel(Thing.Label)).breadthFirstSearch).property(Name).toSetMutable shouldBe expectedResults
     }
   }
 
   "support repeat/while behaviour" should {
     "base case: given `whilst` condition is also evaluated for first iteration" in {
-      centerTrav.repeat(_.followedBy)(_.whilst(_.name("does not exist"))).toSet shouldBe Set(center)
-      centerTrav.repeat(_.out)(_.whilst(_.has(Name, "does not exist"))).toSet shouldBe Set(center)
+      centerTrav.repeat(_.followedBy)(_.whilst(_.name("does not exist"))).toSetMutable shouldBe Set(center)
+      centerTrav.repeat(_.out)(_.whilst(_.has(Name, "does not exist"))).toSetMutable shouldBe Set(center)
     }
 
     "walk one iteration" in {
-      centerTrav.repeat(_.followedBy)(_.whilst(_.name("Center"))).toSet shouldBe Set(l1, r1)
-      centerTrav.repeat(_.out)(_.whilst(_.has(Name, "Center"))).toSet shouldBe Set(l1, r1)
+      centerTrav.repeat(_.followedBy)(_.whilst(_.name("Center"))).toSetMutable shouldBe Set(l1, r1)
+      centerTrav.repeat(_.out)(_.whilst(_.has(Name, "Center"))).toSetMutable shouldBe Set(l1, r1)
     }
 
     "walk two iterations" in {
       centerTrav.repeat(_.followedBy)(_.whilst(_.or(
         _.name("Center"),
         _.nameEndsWith("1")
-      ))).toSet shouldBe Set(l2, r2)
+      ))).toSetMutable shouldBe Set(l2, r2)
 
       centerTrav.repeat(_.out)(_.whilst(_.or(
         _.has(Name.where(_.endsWith("1"))),
         _.has(Name, "Center"),
-      ))).toSet shouldBe Set(l2, r2)
+      ))).toSetMutable shouldBe Set(l2, r2)
     }
 
     "emitting nodes along the way" in {
-      centerTrav.repeat(_.followedBy)(_.emit.whilst(_.name("Center"))).toSet shouldBe Set(center, l1, r1)
-      centerTrav.repeat(_.followedBy)(_.emitAllButFirst.whilst(_.name("Center"))).toSet shouldBe Set(l1, r1)
+      centerTrav.repeat(_.followedBy)(_.emit.whilst(_.name("Center"))).toSetMutable shouldBe Set(center, l1, r1)
+      centerTrav.repeat(_.followedBy)(_.emitAllButFirst.whilst(_.name("Center"))).toSetMutable shouldBe Set(l1, r1)
     }
 
     "with path tracking enabled" in {
-      centerTrav.enablePathTracking.repeat(_.followedBy)(_.whilst(_.name("Center"))).path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.repeat(_.followedBy)(_.whilst(_.name("Center"))).path.toSetMutable shouldBe Set(
         Seq(center, r1),
         Seq(center, l1),
       )
@@ -153,22 +153,22 @@ class RepeatTraversalTests extends AnyWordSpec {
 
   ".dedup should apply to all repeat iterations" when {
     "path tracking is not enabled" in {
-      centerTrav.repeat(_.both)(_.times(2).dedup).toSet shouldBe Set(l2, r2)
-      centerTrav.repeat(_.both)(_.times(3).dedup).toSet shouldBe Set(l3, r3)
-      centerTrav.repeat(_.both)(_.times(4).dedup).toSet shouldBe Set(r4)
+      centerTrav.repeat(_.both)(_.times(2).dedup).toSetMutable shouldBe Set(l2, r2)
+      centerTrav.repeat(_.both)(_.times(3).dedup).toSetMutable shouldBe Set(l3, r3)
+      centerTrav.repeat(_.both)(_.times(4).dedup).toSetMutable shouldBe Set(r4)
 
       // for reference, without dedup (order is irrelevant, only using .l to show duplicate `center`)
       centerTrav.repeat(_.both)(_.times(2)).l shouldBe Seq(l2, center, r2, center)
     }
 
     "path tracking is enabled" in {
-      centerTrav.enablePathTracking.repeat(_.both)(_.times(2).dedup).path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.repeat(_.both)(_.times(2).dedup).path.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2)
       )
 
       // for reference, without dedup:
-      centerTrav.enablePathTracking.repeat(_.both)(_.times(2)).path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.repeat(_.both)(_.times(2)).path.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, l1, center),
         Seq(center, r1, r2),
@@ -182,7 +182,7 @@ class RepeatTraversalTests extends AnyWordSpec {
     }
 
     "used with emit and path" in {
-      centerTrav.enablePathTracking.repeat(_.both)(_.times(2).emit.dedup).path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.repeat(_.both)(_.times(2).emit.dedup).path.toSetMutable shouldBe Set(
         Seq(center),
         Seq(center, l1),
         Seq(center, l1, l2),
@@ -209,7 +209,7 @@ class RepeatTraversalTests extends AnyWordSpec {
     "path tracking is not enabled" in {
       val trav = centerTrav.repeat(_.followedBy)(_.times(2))
       trav.hasNext shouldBe true
-      trav.toSet shouldBe Set(l2, r2)
+      trav.toSetMutable shouldBe Set(l2, r2)
     }
 
     "path tracking is enabled" in {
@@ -217,8 +217,8 @@ class RepeatTraversalTests extends AnyWordSpec {
       val trav2 = centerTrav.enablePathTracking.repeat(_.followedBy)(_.times(2)).path
       trav1.hasNext shouldBe true
       trav2.hasNext shouldBe true
-      trav1.toSet shouldBe Set(l2, r2)
-      trav2.toSet shouldBe Set(
+      trav1.toSetMutable shouldBe Set(l2, r2)
+      trav2.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2)
       )
@@ -322,13 +322,13 @@ class RepeatTraversalTests extends AnyWordSpec {
 
   "support .path step" when {
     "using `times` modulator" in {
-      centerTrav.enablePathTracking.repeat(_.out)(_.times(2)).path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.repeat(_.out)(_.times(2)).path.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2))
     }
 
     "using `emit` modulator" in {
-      centerTrav.enablePathTracking.repeat(_.out)(_.emit).path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.repeat(_.out)(_.emit).path.toSetMutable shouldBe Set(
         Seq(center),
         Seq(center, l1),
         Seq(center, l1, l2),
@@ -342,23 +342,23 @@ class RepeatTraversalTests extends AnyWordSpec {
     }
 
     "using `until` modulator" in {
-      centerTrav.enablePathTracking.repeat(_.followedBy)(_.until(_.nameEndsWith("2"))).path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.repeat(_.followedBy)(_.until(_.nameEndsWith("2"))).path.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2))
     }
 
     "using breadth first search" in {
-      centerTrav.enablePathTracking.repeat(_.followedBy)(_.breadthFirstSearch.times(2)).path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.repeat(_.followedBy)(_.breadthFirstSearch.times(2)).path.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2))
     }
 
     "doing multiple steps: should track every single step along the way" in {
-      centerTrav.enablePathTracking.repeat(_.followedBy.followedBy)(_.times(1)).path.toSet shouldBe Set(
+      centerTrav.enablePathTracking.repeat(_.followedBy.followedBy)(_.times(1)).path.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2))
 
-      r1.start.enablePathTracking.repeat(_.followedBy.followedBy.followedBy)(_.times(1)).path.toSet shouldBe Set(
+      r1.start.enablePathTracking.repeat(_.followedBy.followedBy.followedBy)(_.times(1)).path.toSetMutable shouldBe Set(
         Seq(r1, r2, r3, r4))
 
       r1.start.enablePathTracking.repeat(_.out.out)(_.times(2)).l shouldBe Seq(r5)

--- a/traversal/src/test/scala/overflowdb/traversal/TraversalSourceTest.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/TraversalSourceTest.scala
@@ -16,13 +16,13 @@ class TraversalSourceTest extends AnyWordSpec {
     val two2 = graph + (Thing.Label, Name.of("two"))
 
     def verify() = {
-      TraversalSource(graph).has(Name.of("one")).toSet shouldBe Set(one)
-      TraversalSource(graph).has(Name.of("two")).toSet shouldBe Set(two1, two2)
-      TraversalSource(graph).has(Name.of("unknown")).toSet shouldBe Set.empty
+      TraversalSource(graph).has(Name.of("one")).toSetMutable shouldBe Set(one)
+      TraversalSource(graph).has(Name.of("two")).toSetMutable shouldBe Set(two1, two2)
+      TraversalSource(graph).has(Name.of("unknown")).toSetMutable shouldBe Set.empty
 
-      TraversalSource(graph).labelAndProperty(Thing.Label, Name.of("two")).toSet shouldBe Set(two1, two2)
-      TraversalSource(graph).labelAndProperty(Thing.Label, Name.of("unknown")).toSet shouldBe Set.empty
-      TraversalSource(graph).labelAndProperty("unknown", Name.of("two")).toSet shouldBe Set.empty
+      TraversalSource(graph).labelAndProperty(Thing.Label, Name.of("two")).toSetMutable shouldBe Set(two1, two2)
+      TraversalSource(graph).labelAndProperty(Thing.Label, Name.of("unknown")).toSetMutable shouldBe Set.empty
+      TraversalSource(graph).labelAndProperty("unknown", Name.of("two")).toSetMutable shouldBe Set.empty
     }
 
     verify()

--- a/traversal/src/test/scala/overflowdb/traversal/TraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/TraversalTests.scala
@@ -24,7 +24,7 @@ class TraversalTests extends AnyWordSpec {
 
   ".sideEffect step should apply provided function and do nothing else" in {
     val sack = mutable.ListBuffer.empty[Node]
-    center.start.out.sideEffect(sack.addOne).out.toSet shouldBe Set(l2, r2)
+    center.start.out.sideEffect(sack.addOne).out.toSetMutable shouldBe Set(l2, r2)
     sack.toSet shouldBe Set(l1, r1)
   }
 
@@ -39,15 +39,15 @@ class TraversalTests extends AnyWordSpec {
           sack.addOne(node)
       }
       .out
-      .toSet shouldBe Set(l2, r2)
+      .toSetMutable shouldBe Set(l2, r2)
 
     sack.toSet shouldBe Set(l1)
   }
 
   "domain overview" in {
-    simpleDomain.all.property(Thing.Properties.Name).toSet shouldBe Set("L3", "L2", "L1", "Center", "R1", "R2", "R3", "R4", "R5")
+    simpleDomain.all.property(Thing.Properties.Name).toSetMutable shouldBe Set("L3", "L2", "L1", "Center", "R1", "R2", "R3", "R4", "R5")
     centerTrav.head.name shouldBe "Center"
-    simpleDomain.all.label.toSet shouldBe Set(Thing.Label)
+    simpleDomain.all.label.toSetMutable shouldBe Set(Thing.Label)
   }
 
   ".dedup step" should {
@@ -91,7 +91,7 @@ class TraversalTests extends AnyWordSpec {
     "path tracking is not enabled" in {
       val trav = centerTrav.followedBy.followedBy
       trav.hasNext shouldBe true
-      trav.toSet shouldBe Set(l2, r2)
+      trav.toSetMutable shouldBe Set(l2, r2)
     }
 
     "path tracking is enabled" in {
@@ -99,8 +99,8 @@ class TraversalTests extends AnyWordSpec {
       val trav2 = centerTrav.enablePathTracking.followedBy.followedBy.path
       trav1.hasNext shouldBe true
       trav2.hasNext shouldBe true
-      trav1.toSet shouldBe Set(l2, r2)
-      trav2.toSet shouldBe Set(
+      trav1.toSetMutable shouldBe Set(l2, r2)
+      trav2.toSetMutable shouldBe Set(
         Seq(center, l1, l2),
         Seq(center, r1, r2)
       )
@@ -146,7 +146,7 @@ class TraversalTests extends AnyWordSpec {
     val traversal: Traversal[(Int, Traversal[String])] =
       Traversal("aaa", "bbb", "cc").groupBy(_.length)
 
-    val results = traversal.map { case (length, valueTrav) => (length, valueTrav.toSet) }.toSet
+    val results = traversal.map { case (length, valueTrav) => (length, valueTrav.toSetMutable) }.toSetMutable
     results shouldBe Set(
       2 -> Set("cc"),
       3 -> Set("aaa", "bbb"))
@@ -157,7 +157,7 @@ class TraversalTests extends AnyWordSpec {
 
     val Seq(keys -> values) = traversal.l
     keys shouldBe "a"
-    values.toSet shouldBe(Set(1, 2))
+    values.toSetMutable shouldBe(Set(1, 2))
   }
 
   "string filter steps" in {


### PR DESCRIPTION
Add toSetMutable end step to Traversal and use it in tests instead of
toSet.
This becomes necessary because the Scala 3 compiler cannot choose
between toSet defined on our Traversal which has signature
def toSet: mutable.Set[A]
and the toSet of IterableOnceExtensionMethods which has signature
def toSet[B >: A]: immutable.Set[B]
when used in combination with the "should" matchers of scalatest.

In order to not break API we leave the toSet methods as they are and
just change our test code.