### PR TITLE
Explicitly import ThingTraversal.

### DIFF
--- a/traversal/src/test/scala/overflowdb/GraphSugarTests.scala
+++ b/traversal/src/test/scala/overflowdb/GraphSugarTests.scala
@@ -4,7 +4,7 @@ import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.traversal._
 import overflowdb.traversal.testdomains.simple.Connection.Properties.Distance
-import overflowdb.traversal.testdomains.simple.{Connection, SimpleDomain, Thing}
+import overflowdb.traversal.testdomains.simple.{Connection, SimpleDomain, Thing, ThingTraversal}
 import overflowdb.traversal.testdomains.simple.Thing.Properties._
 
 class GraphSugarTests extends AnyWordSpec {

--- a/traversal/src/test/scala/overflowdb/traversal/LogicalStepsTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/LogicalStepsTests.scala
@@ -4,7 +4,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers._
 import overflowdb.Node
 import overflowdb.traversal.testdomains.simple.Thing.Properties.Name
-import overflowdb.traversal.testdomains.simple.{ExampleGraphSetup, Thing}
+import overflowdb.traversal.testdomains.simple.{ExampleGraphSetup, Thing, ThingTraversal}
 
 class LogicalStepsTests extends AnyWordSpec {
   import ExampleGraphSetup._

--- a/traversal/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -4,7 +4,7 @@ import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb._
 import overflowdb.traversal.testdomains.simple.Thing.Properties.Name
-import overflowdb.traversal.testdomains.simple.{ExampleGraphSetup, Thing}
+import overflowdb.traversal.testdomains.simple.{ExampleGraphSetup, Thing, ThingTraversal}
 
 import scala.collection.mutable
 

--- a/traversal/src/test/scala/overflowdb/traversal/RepeatTraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/RepeatTraversalTests.scala
@@ -5,7 +5,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import overflowdb._
 import overflowdb.traversal.filter.P
 import overflowdb.traversal.testdomains.simple.Thing.Properties.Name
-import overflowdb.traversal.testdomains.simple.{Connection, ExampleGraphSetup, SimpleDomain, Thing}
+import overflowdb.traversal.testdomains.simple.{Connection, ExampleGraphSetup, SimpleDomain, Thing, ThingTraversal}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._

--- a/traversal/src/test/scala/overflowdb/traversal/TraversalTests.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/TraversalTests.scala
@@ -3,7 +3,7 @@ package overflowdb.traversal
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.traversal.filter.P
-import overflowdb.traversal.testdomains.simple.{ExampleGraphSetup, SimpleDomain, Thing}
+import overflowdb.traversal.testdomains.simple.{ExampleGraphSetup, SimpleDomain, Thing, ThingTraversal}
 import overflowdb.traversal.testdomains.gratefuldead._
 import overflowdb.{Node, toPropertyKeyOps}
 

--- a/traversal/src/test/scala/overflowdb/traversal/testdomains/gratefuldead/FollowedBy.scala
+++ b/traversal/src/test/scala/overflowdb/traversal/testdomains/gratefuldead/FollowedBy.scala
@@ -5,7 +5,7 @@ import scala.jdk.CollectionConverters._
 
 class FollowedBy(graph: Graph, outVertex: NodeRef[SongDb], inVertex: NodeRef[SongDb])
     extends Edge(graph, FollowedBy.Label, outVertex, inVertex, FollowedBy.PropertyNames.all.asJava) {
-  def weight: Option[Integer] =
+  def weight: Option[Int] =
     Option(property(FollowedBy.Properties.Weight))
 }
 


### PR DESCRIPTION
This is also a preparation for Scala 3 because in Scala 3 implicits from
the package objects are not in implicit lookup scope anymore.