### PR TITLE
pin mvstore to version 1.4 for now

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.pin = [ { groupId = "com.h2database", artifactId="h2-mvstore", version = "1.4." } ]


### PR DESCRIPTION
see https://github.com/h2database/h2database/releases/tag/version-2.0.202

I haven't actually checked, but an upgrade may render old cpgs invalid.
We'd need a migration strategy and proper testing, but given

This should stop further PRs like https://github.com/ShiftLeftSecurity/overflowdb/pull/261