### PR TITLE
Improve BatchedUpdate.DiffGraphBuilder.addEdge API

### DIFF
--- a/core/src/main/java/overflowdb/BatchedUpdate.java
+++ b/core/src/main/java/overflowdb/BatchedUpdate.java
@@ -114,6 +114,15 @@ public class BatchedUpdate {
             return this;
         }
 
+        public DiffGraphBuilder addEdge(Object src, Object dst, String label, Object... properties) {
+            if (!(src instanceof Node || src instanceof DetachedNodeData))
+                throw new RuntimeException("Can only add edges emanating from Node or NewNode, found src " + src.toString() + " of type " + src.getClass());
+            if (!(dst instanceof Node || dst instanceof DetachedNodeData))
+                throw new RuntimeException("Can only add edges ending in Node or NewNode, found dst " + dst.toString() + " of type " + dst.getClass());
+            _buffer.addLast(new CreateEdge(label, src, dst, properties.length > 0 ? properties : null));
+            return this;
+        }
+
         public DiffGraphBuilder addEdge(Node src, Node dst, String label, Object... properties) {
             _buffer.addLast(new CreateEdge(label, src, dst, properties.length > 0 ? properties : null));
             return this;

--- a/core/src/main/java/overflowdb/BatchedUpdate.java
+++ b/core/src/main/java/overflowdb/BatchedUpdate.java
@@ -114,31 +114,12 @@ public class BatchedUpdate {
             return this;
         }
 
-        public DiffGraphBuilder addEdge(Object src, Object dst, String label, Object... properties) {
-            if (!(src instanceof Node || src instanceof DetachedNodeData))
-                throw new RuntimeException("Can only add edges emanating from Node or NewNode, found src " + src.toString() + " of type " + src.getClass());
-            if (!(dst instanceof Node || dst instanceof DetachedNodeData))
-                throw new RuntimeException("Can only add edges ending in Node or NewNode, found dst " + dst.toString() + " of type " + dst.getClass());
-            _buffer.addLast(new CreateEdge(label, src, dst, properties.length > 0 ? properties : null));
+        public DiffGraphBuilder addEdge(NodeOrDetachedNode src, NodeOrDetachedNode dst, String label) {
+            _buffer.addLast(new CreateEdge(label, src, dst, null));
             return this;
         }
 
-        public DiffGraphBuilder addEdge(Node src, Node dst, String label, Object... properties) {
-            _buffer.addLast(new CreateEdge(label, src, dst, properties.length > 0 ? properties : null));
-            return this;
-        }
-
-        public DiffGraphBuilder addEdge(Node src, DetachedNodeData dst, String label, Object... properties) {
-            _buffer.addLast(new CreateEdge(label, src, dst, properties.length > 0 ? properties : null));
-            return this;
-        }
-
-        public DiffGraphBuilder addEdge(DetachedNodeData src, Node dst, String label, Object... properties) {
-            _buffer.addLast(new CreateEdge(label, src, dst, properties.length > 0 ? properties : null));
-            return this;
-        }
-
-        public DiffGraphBuilder addEdge(DetachedNodeData src, DetachedNodeData dst, String label, Object... properties) {
+        public DiffGraphBuilder addEdge(NodeOrDetachedNode src, NodeOrDetachedNode dst, String label, Object... properties) {
             _buffer.addLast(new CreateEdge(label, src, dst, properties.length > 0 ? properties : null));
             return this;
         }
@@ -222,11 +203,11 @@ public class BatchedUpdate {
 
     public static class CreateEdge implements Change {
         public String label;
-        public Object src;
-        public Object dst;
+        public NodeOrDetachedNode src;
+        public NodeOrDetachedNode dst;
         public Object[] propertiesAndKeys;
 
-        public CreateEdge(String label, Object src, Object dst, Object[] propertiesAndKeys) {
+        public CreateEdge(String label, NodeOrDetachedNode src, NodeOrDetachedNode dst, Object[] propertiesAndKeys) {
             this.label = label;
             this.src = src;
             this.dst = dst;

--- a/core/src/main/java/overflowdb/DetachedNodeData.java
+++ b/core/src/main/java/overflowdb/DetachedNodeData.java
@@ -3,7 +3,7 @@ package overflowdb;
 import overflowdb.BatchedUpdate;
 import overflowdb.Node;
 
-public interface DetachedNodeData extends BatchedUpdate.Change {
+public interface DetachedNodeData extends BatchedUpdate.Change, NodeOrDetachedNode {
         public String label();
         /** RefOrId is initially null, and can be a Long if a specific id is required,
          * and is set to Node once the node has been added to the graph.

--- a/core/src/main/java/overflowdb/Node.java
+++ b/core/src/main/java/overflowdb/Node.java
@@ -6,7 +6,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Function;
 
-public abstract class Node extends Element {
+public abstract class Node extends Element implements NodeOrDetachedNode {
 
   /**
    * Add an outgoing edge to the node with provided label and edge properties as key/value pairs.

--- a/core/src/main/java/overflowdb/NodeOrDetachedNode.java
+++ b/core/src/main/java/overflowdb/NodeOrDetachedNode.java
@@ -1,0 +1,4 @@
+package overflowdb;
+
+public interface NodeOrDetachedNode {
+}


### PR DESCRIPTION
During porting of our giant collection of passes, I stumbled upon the problem that I naively assumed that the age (NewNode vs StoredNode) of src and dst nodes is always statically known. This is not true for many passes.

The old api functions are retained for binary compatibility. The new addEdge function takes Object and does runtime checks, because nobody needs union types, right?

Note that the scala API looked somewhat nicer, because there is a more sensible `AbstractNode` shared supertype of NewNode and StoredNode. Since these are not odb concepts, we cannot do this here.