### PR TITLE
Add defensive null-checks for MDC in order work around logback awesomeness

### DIFF
--- a/core/src/main/java/overflowdb/HeapUsageMonitor.java
+++ b/core/src/main/java/overflowdb/HeapUsageMonitor.java
@@ -80,13 +80,19 @@ public class HeapUsageMonitor implements AutoCloseable {
         if (heapUsage > heapUsageThreshold) {
           Map<String, String> oldMDC = MDC.getCopyOfContextMap();
           try{
-            MDC.setContextMap(capturedMDC);
+            //logback chokes on null-maps
+            if(capturedMDC != null) MDC.setContextMap(capturedMDC);
+            else MDC.clear();
             String msg = "heap usage after GC: " + heapUsagePercent + "% -> will clear some references (if possible)";
             if (heapUsagePercent > 95) logger.warn(msg);
             else logger.info(msg);
 
             notificationListener.notifyHeapAboveThreshold();
-          } finally{ MDC.setContextMap(oldMDC); }
+          } finally{
+            //logback chokes on null-maps
+            if(oldMDC != null) MDC.setContextMap(oldMDC);
+            else MDC.clear();
+          }
         } else {
           // note: this message won't have correct MDC, but that shouldn't matter too much
           logger.trace("heap usage after GC: " + heapUsagePercent + "%");

--- a/core/src/main/java/overflowdb/util/NamedThreadFactory.java
+++ b/core/src/main/java/overflowdb/util/NamedThreadFactory.java
@@ -7,10 +7,14 @@ import java.util.concurrent.ThreadFactory;
 
 public class NamedThreadFactory implements ThreadFactory {
   private final String threadName;
-  private final Map<String, String> mdc = MDC.getCopyOfContextMap();
+  private final Map<String, String> mdc;
 
   public NamedThreadFactory(String threadName) {
+
     this.threadName = threadName;
+    Map<String, String> mdcTmp = = MDC.getCopyOfContextMap();
+    //logback chokes on null-maps
+    this.mdc = mdcTmp != null ? mdcTmp : new Map<String, String>();
   }
 
   public Thread newThread(Runnable r) {

--- a/core/src/main/java/overflowdb/util/NamedThreadFactory.java
+++ b/core/src/main/java/overflowdb/util/NamedThreadFactory.java
@@ -2,6 +2,7 @@ package overflowdb.util;
 
 import org.slf4j.MDC;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadFactory;
 
@@ -12,9 +13,9 @@ public class NamedThreadFactory implements ThreadFactory {
   public NamedThreadFactory(String threadName) {
 
     this.threadName = threadName;
-    Map<String, String> mdcTmp = = MDC.getCopyOfContextMap();
+    Map<String, String> mdcTmp = MDC.getCopyOfContextMap();
     //logback chokes on null-maps
-    this.mdc = mdcTmp != null ? mdcTmp : new Map<String, String>();
+    this.mdc = mdcTmp != null ? mdcTmp : new HashMap<>();
   }
 
   public Thread newThread(Runnable r) {


### PR DESCRIPTION
Some versions of logback return null-pointer on `getCopyOfContextMap()` and then choke on `setContextMap(null)`.

Great API design all around! Good on us that we're using lol4j, that one doesn't choke on null-pointers, and even supports hot-loading of plugin functionality.

Thanks to BigDataDave for reporting the issue on discord.