### PR TITLE
graphml as import/export format

### DIFF
--- a/core-tests/src/test/java/overflowdb/IndexesTest.java
+++ b/core-tests/src/test/java/overflowdb/IndexesTest.java
@@ -1,9 +1,8 @@
 package overflowdb;
 
-import overflowdb.formats.GraphMLImport;
-import overflowdb.testdomains.gratefuldead.GratefulDead;
-
 import org.junit.Test;
+import overflowdb.formats.graphml.GraphMLImporter;
+import overflowdb.testdomains.gratefuldead.GratefulDead;
 
 import java.io.File;
 import java.io.IOException;
@@ -132,7 +131,7 @@ public class IndexesTest {
 
   public static Graph openAndLoadSampleData(String path) {
     Graph graph = GratefulDead.newGraph(Config.withDefaults().withStorageLocation(path));
-    GraphMLImport.runImport(graph, "src/test/resources/grateful-dead.xml");
+    GraphMLImporter.runImport(graph, "src/test/resources/grateful-dead.xml");
     return graph;
   }
 

--- a/core-tests/src/test/java/overflowdb/storage/GraphSaveRestoreTest.java
+++ b/core-tests/src/test/java/overflowdb/storage/GraphSaveRestoreTest.java
@@ -1,11 +1,11 @@
 package overflowdb.storage;
 
 import org.junit.Test;
-import overflowdb.Node;
 import overflowdb.Config;
 import overflowdb.Edge;
 import overflowdb.Graph;
-import overflowdb.formats.GraphMLImport;
+import overflowdb.Node;
+import overflowdb.formats.graphml.GraphMLImporter;
 import overflowdb.testdomains.gratefuldead.FollowedBy;
 import overflowdb.testdomains.gratefuldead.GratefulDead;
 import overflowdb.testdomains.gratefuldead.Song;
@@ -185,7 +185,7 @@ public class GraphSaveRestoreTest {
   }
 
   private void loadGraphMl(Graph graph) {
-    GraphMLImport.runImport(graph, "src/test/resources/grateful-dead.xml");
+    GraphMLImporter.runImport(graph, "src/test/resources/grateful-dead.xml");
   }
 
   private Iterator<Node> getSongs(Graph graph, String songName) {

--- a/formats/src/main/scala/overflowdb/formats/Exporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/Exporter.scala
@@ -10,4 +10,4 @@ trait Exporter {
     runExport(graph, Path.of(outputFile))
 }
 
-case class ExportResult(nodeCount: Int, edgeCount: Int, files: Seq[Path], additionalInfo: String)
+case class ExportResult(nodeCount: Int, edgeCount: Int, files: Seq[Path], additionalInfo: Option[String])

--- a/formats/src/main/scala/overflowdb/formats/ExporterMain.scala
+++ b/formats/src/main/scala/overflowdb/formats/ExporterMain.scala
@@ -1,6 +1,7 @@
 package overflowdb.formats
 
 import org.slf4j.LoggerFactory
+import overflowdb.formats.graphml.GraphMLExporter
 import overflowdb.{EdgeFactory, Graph, NodeFactory}
 import overflowdb.formats.neo4jcsv.Neo4jCsvExporter
 
@@ -35,7 +36,7 @@ object ExporterMain {
 
           val exporter: Exporter = format match {
             case Format.Neo4jCsv => Neo4jCsvExporter
-            case Format.GraphMl => ???
+            case Format.GraphMl => GraphMLExporter
           }
           val odbConfig = overflowdb.Config.withoutOverflow.withStorageLocation(inputFile)
           logger.info(s"starting export of graph in $inputFile to storagePath=$outputFile in format=$format")
@@ -44,7 +45,7 @@ object ExporterMain {
               exporter.runExport(graph, outputFile)
             }
           logger.info(s"export completed successfully: $nodeCount nodes, $edgeCount edges in ${files.size} files")
-          logger.info(additionalInfo)
+          additionalInfo.foreach(logger.info)
         }
     }
 

--- a/formats/src/main/scala/overflowdb/formats/ImporterMain.scala
+++ b/formats/src/main/scala/overflowdb/formats/ImporterMain.scala
@@ -1,6 +1,7 @@
 package overflowdb.formats
 
 import org.slf4j.LoggerFactory
+import overflowdb.formats.graphml.GraphMLImport
 import overflowdb.formats.neo4jcsv.Neo4jCsvImporter
 import overflowdb.{EdgeFactory, Graph, NodeFactory}
 import scopt.OParser

--- a/formats/src/main/scala/overflowdb/formats/ImporterMain.scala
+++ b/formats/src/main/scala/overflowdb/formats/ImporterMain.scala
@@ -1,7 +1,7 @@
 package overflowdb.formats
 
 import org.slf4j.LoggerFactory
-import overflowdb.formats.graphml.GraphMLImport
+import overflowdb.formats.graphml.GraphMLImporter
 import overflowdb.formats.neo4jcsv.Neo4jCsvImporter
 import overflowdb.{EdgeFactory, Graph, NodeFactory}
 import scopt.OParser
@@ -35,7 +35,7 @@ object ImporterMain extends App {
 
           val importer: Importer = format match {
             case Format.Neo4jCsv => Neo4jCsvImporter
-            case Format.GraphMl => GraphMLImport
+            case Format.GraphMl => GraphMLImporter
           }
           val odbConfig = overflowdb.Config.withoutOverflow.withStorageLocation(outputFile)
           Using.resource(

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -7,6 +7,7 @@ import java.lang.System.lineSeparator
 import java.nio.file.{Files, Path}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.{IterableHasAsScala, IteratorHasAsScala, MapHasAsScala}
+import scala.xml.{PrettyPrinter, XML}
 
 /**
  * Exports OverflowDB Graph to GraphML
@@ -67,8 +68,8 @@ object GraphMLExporter extends Exporter {
        |    </graph>
        |</graphml>
        |""".stripMargin.strip
-
     Files.writeString(outFile, xml)
+    xmlFormatInPlace(outFile)
 
     ExportResult(
       nodeCount = nodeEntries.size,
@@ -149,4 +150,12 @@ object GraphMLExporter extends Exporter {
       case _ => value.toString
     }
   }
+
+  private def xmlFormatInPlace(xmlFile: Path): Unit = {
+    val xml = XML.loadFile(xmlFile.toFile)
+    val prettyPrinter = new PrettyPrinter(120, 2)
+    val formatted = prettyPrinter.format(xml)
+    Files.writeString(xmlFile, formatted)
+  }
+
 }

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -9,7 +9,10 @@ import scala.jdk.CollectionConverters.{IterableHasAsScala, IteratorHasAsScala, M
 
 /**
  * Exports OverflowDB Graph to GraphML
+ *
  * Note: GraphML doesn't natively support list property types, so we fake it by encoding it as a `;` delimited string.
+ * If you import this into a different database, you'll need to parse that separately.
+ * In comparison, Tinkerpop just bails out if you try to export a list property to graphml.
  *
  * https://en.wikipedia.org/wiki/GraphML
  * http://graphml.graphdrawing.org/primer/graphml-primer.html

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -1,10 +1,15 @@
 package overflowdb.formats.graphml
 
 import overflowdb.Graph
-import overflowdb.formats.{CountAndFiles, ExportResult, Exporter}
-import java.nio.file.Path
+import overflowdb.formats.{ExportResult, Exporter}
 
-object GraphMLExporter  extends Exporter {
+import java.nio.file.Path
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsScala}
+
+object GraphMLExporter extends Exporter {
+  val KeyForNodeLabel = "labelV"
+  val KeyForEdgeLabel = "labelE"
 
   /**
    * Exports OverflowDB Graph to graphml
@@ -12,24 +17,75 @@ object GraphMLExporter  extends Exporter {
    * http://graphml.graphdrawing.org/primer/graphml-primer.html
    * */
   override def runExport(graph: Graph, outputRootDirectory: Path) = {
-    //    val CountAndFiles(nodeCount, nodeFiles) = labelsWithNodes(graph).map { label =>
-    //      exportNodes(graph, label, outputRootDirectory)
-    //    }.reduce(_.plus(_))
-    //    val CountAndFiles(edgeCount, edgeFiles) = exportEdges(graph, outputRootDirectory)
-    //
-    //    ExportResult(
-    //      nodeCount,
-    //      edgeCount,
-    //      files = nodeFiles ++ edgeFiles,
-    //      s"""instructions on how to import the exported files into neo4j:
-    //         |```
-    //         |cp $outputRootDirectory/*$DataFileSuffix.csv <neo4j_root>/import
-    //         |cd <neo4j_root>
-    //         |find $outputRootDirectory -name 'nodes_*_cypher.csv' -exec bin/cypher-shell -u <neo4j_user> -p <password> --file {} \\;
-    //         |find $outputRootDirectory -name 'edges_*_cypher.csv' -exec bin/cypher-shell -u <neo4j_user> -p <password> --file {} \\;
-    //         |```
-    //         |""".stripMargin
-    //    )
-    ???
+    val propertyTypeByName = mutable.Map.empty[String, Type.Value]
+
+    val nodes = graph.nodes().asScala.map { node =>
+      val keyEntries = {
+        node.propertiesMap().asScala.map { case (key, value) =>
+          // update type information based on runtime instances
+          if (!propertyTypeByName.contains(key)) {
+            propertyTypeByName.update(key, Type.fromRuntimeClass(value.getClass))
+          }
+          s"""<data key="$key">$value</data>"""
+        }
+      }.mkString("\n")
+
+      s"""<node id="${node.id}">
+         |    <data key="$KeyForNodeLabel">${node.label}</data>
+         |    $keyEntries
+         |</node>
+         |""".stripMargin
+    }
+
+    // TODO propertyTypeByName needs to be grouped by label... properties could have different types for different labels...
+
+    //    graph.edges().forEachRemaining { edge =>
+//
+//    }
+
+    // TODO write to output dir/file
+        ExportResult(
+          nodes.size,
+          -1,
+          files = Nil,
+          None
+        )
+  }
+
+  private def xmlDocument(body: String) =
+    s"""
+      |<?xml version="1.0" encoding="UTF-8"?>
+      |<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
+      |    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      |    xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
+      |     http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+      |$body
+      |</graphml>
+      |""".stripMargin
+
+  object Type extends Enumeration {
+    val Boolean = Value("boolean")
+    val Int = Value("int")
+    val Long = Value("long")
+    val Float = Value("float")
+    val Double = Value("double")
+    val String = Value("string")
+
+    def fromRuntimeClass(clazz: Class[_]): Type.Value = {
+      if (clazz.isAssignableFrom(classOf[Boolean]))
+        Type.Boolean
+      else if (clazz.isAssignableFrom(classOf[Int]))
+        Type.Int
+      else if (clazz.isAssignableFrom(classOf[Long]))
+        Type.Long
+      else if (clazz.isAssignableFrom(classOf[Float]))
+        Type.Float
+      else if (clazz.isAssignableFrom(classOf[Double]))
+        Type.Double
+      else if (clazz.isAssignableFrom(classOf[String]))
+        Type.String
+      else
+        throw new AssertionError(s"unsupported runtime class `$clazz` - only ${Type.values.mkString("|")} are supported...}")
+    }
   }
 }

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -30,7 +30,7 @@ object GraphMLExporter extends Exporter {
     }.toSeq
 
     val edgeEntries = graph.edges().asScala.map { edge =>
-      s"""<edge source="${edge.inNode.id}" target="${edge.outNode.id}">
+      s"""<edge source="${edge.outNode.id}" target="${edge.inNode.id}">
          |    <data key="$KeyForEdgeLabel">${edge.label}</data>
          |    ${dataEntries("edge", edge, edgePropertyContextById)}
          |</edge>

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -7,15 +7,17 @@ import java.nio.file.{Files, Path}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsScala}
 
+/**
+ * Exports OverflowDB Graph to GraphML
+ * Note: GraphML doesn't natively support list property types, so we fake it by encoding it as a `;` delimited string.
+ *
+ * https://en.wikipedia.org/wiki/GraphML
+ * http://graphml.graphdrawing.org/primer/graphml-primer.html
+ * */
 object GraphMLExporter extends Exporter {
   val KeyForNodeLabel = "labelV"
   val KeyForEdgeLabel = "labelE"
 
-  /**
-   * Exports OverflowDB Graph to graphml
-   * https://en.wikipedia.org/wiki/GraphML
-   * http://graphml.graphdrawing.org/primer/graphml-primer.html
-   * */
   override def runExport(graph: Graph, outputRootDirectory: Path) = {
     val outFile = resolveOutputFile(outputRootDirectory)
     val nodePropertyContextById = mutable.Map.empty[String, PropertyContext]

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -106,13 +106,15 @@ object GraphMLExporter extends Exporter {
       if (isList(propertyValue.getClass)) {
         tryDeriveListValueType(propertyValue).map { valueTpe =>
           updatePropertyContext(valueTpe, true)
-          val valueEncoded = encodeListValue(propertyValue)
-          s"""<data key="$encodedPropertyName">$valueEncoded</data>"""
+          val listEncoded = encodeListValue(propertyValue)
+          val xmlEncoded = xml.Utility.escape(listEncoded)
+          s"""<data key="$encodedPropertyName">$xmlEncoded</data>"""
         }.getOrElse("") // if list is empty, don't even create a data entry
       } else { // scalar value
         val graphMLTpe = Type.fromRuntimeClass(propertyValue.getClass)
         updatePropertyContext(graphMLTpe, false)
-        s"""<data key="$encodedPropertyName">$propertyValue</data>"""
+        val xmlEncoded = xml.Utility.escape(propertyValue.toString)
+        s"""<data key="$encodedPropertyName">$xmlEncoded</data>"""
       }
     }.mkString(lineSeparator)
   }

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -1,0 +1,35 @@
+package overflowdb.formats.graphml
+
+import overflowdb.Graph
+import overflowdb.formats.{CountAndFiles, ExportResult, Exporter}
+import java.nio.file.Path
+
+object GraphMLExporter  extends Exporter {
+
+  /**
+   * Exports OverflowDB Graph to graphml
+   * https://en.wikipedia.org/wiki/GraphML
+   * http://graphml.graphdrawing.org/primer/graphml-primer.html
+   * */
+  override def runExport(graph: Graph, outputRootDirectory: Path) = {
+    //    val CountAndFiles(nodeCount, nodeFiles) = labelsWithNodes(graph).map { label =>
+    //      exportNodes(graph, label, outputRootDirectory)
+    //    }.reduce(_.plus(_))
+    //    val CountAndFiles(edgeCount, edgeFiles) = exportEdges(graph, outputRootDirectory)
+    //
+    //    ExportResult(
+    //      nodeCount,
+    //      edgeCount,
+    //      files = nodeFiles ++ edgeFiles,
+    //      s"""instructions on how to import the exported files into neo4j:
+    //         |```
+    //         |cp $outputRootDirectory/*$DataFileSuffix.csv <neo4j_root>/import
+    //         |cd <neo4j_root>
+    //         |find $outputRootDirectory -name 'nodes_*_cypher.csv' -exec bin/cypher-shell -u <neo4j_user> -p <password> --file {} \\;
+    //         |find $outputRootDirectory -name 'edges_*_cypher.csv' -exec bin/cypher-shell -u <neo4j_user> -p <password> --file {} \\;
+    //         |```
+    //         |""".stripMargin
+    //    )
+    ???
+  }
+}

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -15,8 +15,6 @@ import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsScala}
  * http://graphml.graphdrawing.org/primer/graphml-primer.html
  * */
 object GraphMLExporter extends Exporter {
-  val KeyForNodeLabel = "labelV"
-  val KeyForEdgeLabel = "labelE"
 
   override def runExport(graph: Graph, outputRootDirectory: Path) = {
     val outFile = resolveOutputFile(outputRootDirectory)
@@ -97,32 +95,4 @@ object GraphMLExporter extends Exporter {
       s"""<data key="$encodedPropertyName">$propertyValue</data>"""
     }.mkString("\n")
   }
-
-  object Type extends Enumeration {
-    val Boolean = Value("boolean")
-    val Int = Value("int")
-    val Long = Value("long")
-    val Float = Value("float")
-    val Double = Value("double")
-    val String = Value("string")
-
-    def fromRuntimeClass(clazz: Class[_]): Type.Value = {
-      if (clazz.isAssignableFrom(classOf[Boolean]) || clazz.isAssignableFrom(classOf[java.lang.Boolean]))
-        Type.Boolean
-      else if (clazz.isAssignableFrom(classOf[Int]) || clazz.isAssignableFrom(classOf[Integer]))
-        Type.Int
-      else if (clazz.isAssignableFrom(classOf[Long]) || clazz.isAssignableFrom(classOf[java.lang.Long]))
-        Type.Long
-      else if (clazz.isAssignableFrom(classOf[Float]) || clazz.isAssignableFrom(classOf[java.lang.Float]))
-        Type.Float
-      else if (clazz.isAssignableFrom(classOf[Double]) || clazz.isAssignableFrom(classOf[java.lang.Double]))
-        Type.Double
-      else if (clazz.isAssignableFrom(classOf[String]))
-        Type.String
-      else
-        throw new AssertionError(s"unsupported runtime class `$clazz` - only ${Type.values.mkString("|")} are supported...}")
-    }
-  }
-
-  private case class PropertyContext(name: String, tpe: Type.Value)
 }

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -90,20 +90,20 @@ object GraphMLExporter extends Exporter {
       val graphMLTpe = Type.fromRuntimeClass(propertyValue.getClass)
 
       /* update type information based on runtime instances */
-      def updatePropertyContext(graphMLTpe: => Option[Type.Value]) = {
+      def updatePropertyContext(valueTpe: Type.Value) = {
         if (!propertyContextById.contains(encodedPropertyName)) {
-          graphMLTpe.map { valueTpe =>
-            propertyContextById.update(encodedPropertyName, PropertyContext(propertyName, valueTpe))
-          }
+          propertyContextById.update(encodedPropertyName, PropertyContext(propertyName, valueTpe))
         }
       }
 
       if (graphMLTpe == Type.List) {
-        updatePropertyContext(tryDeriveListValueType(propertyValue))
-        val valueEncoded = encodeListValue(propertyValue)
-        s"""<data key="$encodedPropertyName">$valueEncoded</data>"""
+        tryDeriveListValueType(propertyValue).map { valueTpe =>
+          updatePropertyContext(valueTpe)
+          val valueEncoded = encodeListValue(propertyValue)
+          s"""<data key="$encodedPropertyName">$valueEncoded</data>"""
+        }.getOrElse("") // if list is empty, don't even create a data entry
       } else { // scalar value
-        updatePropertyContext(Option(graphMLTpe))
+        updatePropertyContext(graphMLTpe)
         s"""<data key="$encodedPropertyName">$propertyValue</data>"""
       }
     }.mkString("\n")

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImport.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImport.scala
@@ -1,6 +1,7 @@
-package overflowdb.formats
+package overflowdb.formats.graphml
 
 import overflowdb.Graph
+import overflowdb.formats.Importer
 
 import java.nio.file.Path
 import scala.xml.XML

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
@@ -11,15 +11,15 @@ import scala.xml.XML
 object GraphMLImporter extends Importer {
 
   override def runImport(graph: Graph, inputFiles: Seq[Path]): Unit = {
-    inputFiles.foreach { inputFile =>
-      val doc = XML.loadFile(inputFile.toFile)
-      val graphXml = doc \ "graph"
-      for (node <- graphXml \ "node") {
-        addNode(graph, node)
-      }
-      for (edge <- graphXml \ "edge") {
-        addEdge(graph, edge)
-      }
+    assert(inputFiles.size == 1, s"input must be exactly one file, but got ${inputFiles.size}")
+    val doc = XML.loadFile(inputFiles.head.toFile)
+    val graphXml = doc \ "graph"
+
+    for (node <- graphXml \ "node") {
+      addNode(graph, node)
+    }
+    for (edge <- graphXml \ "edge") {
+      addEdge(graph, edge)
     }
   }
 

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
@@ -47,8 +47,13 @@ object GraphMLImporter extends Importer {
         val id = node \@ "id"
         val name = node \@ "attr.name"
         val graphmlType = node \@ "attr.type"
-        val tpe = Type.withName(graphmlType)
-        (id, PropertyContext(name, tpe))
+
+        // warning: this is derivating from the graphml spec - we do want to support list properties...
+        val isList = graphmlType.endsWith("[]")
+        val tpe =
+          if (isList) Type.withName(graphmlType.dropRight(2))
+          else Type.withName(graphmlType)
+        (id, PropertyContext(name, tpe, isList))
       }
       .toMap
   }
@@ -63,9 +68,9 @@ object GraphMLImporter extends Importer {
       entry \@ "key" match {
         case KeyForNodeLabel => label = Option(value)
         case key =>
-          val PropertyContext(name, tpe) = propertyContextById.get(key).getOrElse(
+          val PropertyContext(name, tpe, isList) = propertyContextById.get(key).getOrElse(
               throw new AssertionError(s"key $key not found in propertyContext..."))
-          val convertedValue = convertValue(value, tpe, context = node)
+          val convertedValue = convertValue(value, tpe, isList, context = node)
           keyValuePairs.addAll(Seq(name, convertedValue))
       }
     }
@@ -87,9 +92,9 @@ object GraphMLImporter extends Importer {
       entry \@ "key" match {
         case KeyForEdgeLabel => label = Option(value)
         case key =>
-          val PropertyContext(name, tpe) = propertyContextById.get(key).getOrElse(
+          val PropertyContext(name, tpe, isList) = propertyContextById.get(key).getOrElse(
             throw new AssertionError(s"key $key not found in propertyContext..."))
-          val convertedValue = convertValue(value, tpe, context = edge)
+          val convertedValue = convertValue(value, tpe, isList, context = edge)
           keyValuePairs.addAll(Seq(name, convertedValue))
       }
     }
@@ -103,15 +108,15 @@ object GraphMLImporter extends Importer {
     } source.addEdge(label, target, keyValuePairs.result: _*)
   }
 
-  private def convertValue(stringValue: String, tpe: Type.Value, context: scala.xml.Node): Any = {
-    tryConvertScalarValue(stringValue, tpe)
-      .orElse(Try {
-        val values = stringValue.split(';').map(value =>
-          tryConvertScalarValue(value, tpe).get // if parsing fails, we do want to escalate
-        )
-        ArraySeq.unsafeWrapArray(values).asJava
-      })
-    match {
+  private def convertValue(stringValue: String, tpe: Type.Value, isList: Boolean, context: scala.xml.Node): Any = {
+    if (isList) {
+      val values = stringValue.split(';').map(value =>
+        tryConvertScalarValue(value, tpe).get // if parsing fails, we do want to escalate
+      )
+      ArraySeq.unsafeWrapArray(values).asJava
+    } else {
+      tryConvertScalarValue(stringValue, tpe)
+    } match {
       case Success(value) => value
       case Failure(e) => throw new AssertionError(
         s"unable to parse `$stringValue` of tpe=$tpe. context: $context", e)

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
@@ -47,7 +47,7 @@ object GraphMLImporter extends Importer {
         val name = node \@ "attr.name"
         val graphmlType = node \@ "attr.type"
 
-        // warning: this is derivating from the graphml spec - we do want to support list properties...
+        // warning: this is deviating from the graphml spec - we do want to support list properties...
         val isList = graphmlType.endsWith("[]")
         val tpe =
           if (isList) Type.withName(graphmlType.dropRight(2))

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
@@ -4,6 +4,8 @@ import overflowdb.Graph
 import overflowdb.formats.{Importer, graphml}
 
 import java.nio.file.Path
+import scala.collection.immutable.ArraySeq
+import scala.jdk.CollectionConverters.IterableHasAsJava
 import scala.util.{Failure, Success, Try}
 import scala.xml.{NodeSeq, XML}
 
@@ -110,13 +112,15 @@ object GraphMLImporter extends Importer {
         case Type.Float => stringValue.toLong
         case Type.Double => stringValue.toDouble
         case Type.String => stringValue
-        case Type.List => ???
+        case Type.List => deencodeListValue(stringValue)
       }
     } match {
       case Success(value) => value
       case Failure(e) => throw new AssertionError(
-        s"unable to parse stringValue=`$stringValue` of tpe=$tpe. context: $context", e)
+        s"unable to parse `$stringValue` of tpe=$tpe. context: $context", e)
     }
   }
 
+  def deencodeListValue(value: String): java.lang.Iterable[String] =
+    ArraySeq.unsafeWrapArray(value.split(';')).asJava
 }

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
@@ -110,6 +110,7 @@ object GraphMLImporter extends Importer {
         case Type.Float => stringValue.toLong
         case Type.Double => stringValue.toDouble
         case Type.String => stringValue
+        case Type.List => ???
       }
     } match {
       case Success(value) => value

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
@@ -6,8 +6,13 @@ import overflowdb.formats.Importer
 import java.nio.file.Path
 import scala.xml.XML
 
-/** primitive GraphML importer which doesn't support much from the spec...
- *  only enough to get us covered for some standard test cases, really */
+/**
+ * Imports GraphML into OverflowDB
+ * Note: GraphML doesn't natively support list property types, so we fake it by encoding it as a `;` delimited string.
+ *
+ * https://en.wikipedia.org/wiki/GraphML
+ * http://graphml.graphdrawing.org/primer/graphml-primer.html
+ * */
 object GraphMLImporter extends Importer {
 
   override def runImport(graph: Graph, inputFiles: Seq[Path]): Unit = {

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
@@ -11,7 +11,6 @@ import scala.xml.{NodeSeq, XML}
 
 /**
  * Imports GraphML into OverflowDB
- * Note: GraphML doesn't natively support list property types, so we fake it by encoding it as a `;` delimited string.
  *
  * https://en.wikipedia.org/wiki/GraphML
  * http://graphml.graphdrawing.org/primer/graphml-primer.html

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLImporter.scala
@@ -8,7 +8,7 @@ import scala.xml.XML
 
 /** primitive GraphML importer which doesn't support much from the spec...
  *  only enough to get us covered for some standard test cases, really */
-object GraphMLImport extends Importer {
+object GraphMLImporter extends Importer {
 
   override def runImport(graph: Graph, inputFiles: Seq[Path]): Unit = {
     inputFiles.foreach { inputFile =>

--- a/formats/src/main/scala/overflowdb/formats/graphml/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/package.scala
@@ -1,0 +1,36 @@
+package overflowdb.formats
+
+package object graphml {
+  // we could/should make these configurable...
+  val KeyForNodeLabel = "labelV"
+  val KeyForEdgeLabel = "labelE"
+
+  object Type extends Enumeration {
+    val Boolean = Value("boolean")
+    val Int = Value("int")
+    val Long = Value("long")
+    val Float = Value("float")
+    val Double = Value("double")
+    val String = Value("string")
+
+    def fromRuntimeClass(clazz: Class[_]): Type.Value = {
+      if (clazz.isAssignableFrom(classOf[Boolean]) || clazz.isAssignableFrom(classOf[java.lang.Boolean]))
+        Type.Boolean
+      else if (clazz.isAssignableFrom(classOf[Int]) || clazz.isAssignableFrom(classOf[Integer]))
+        Type.Int
+      else if (clazz.isAssignableFrom(classOf[Long]) || clazz.isAssignableFrom(classOf[java.lang.Long]))
+        Type.Long
+      else if (clazz.isAssignableFrom(classOf[Float]) || clazz.isAssignableFrom(classOf[java.lang.Float]))
+        Type.Float
+      else if (clazz.isAssignableFrom(classOf[Double]) || clazz.isAssignableFrom(classOf[java.lang.Double]))
+        Type.Double
+      else if (clazz.isAssignableFrom(classOf[String]))
+        Type.String
+      else
+        throw new AssertionError(s"unsupported runtime class `$clazz` - only ${Type.values.mkString("|")} are supported...}")
+    }
+  }
+
+  private[graphml] case class PropertyContext(name: String, tpe: Type.Value)
+
+}

--- a/formats/src/main/scala/overflowdb/formats/graphml/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/package.scala
@@ -13,6 +13,11 @@ package object graphml {
     val Double = Value("double")
     val String = Value("string")
 
+    /** Warning: list properties are not natively supported by graphml...
+     *  For our purposes we fake it by encoding it as a `;` separated string - if you import this into a different database, you'll need to parse that separately.
+     *  In comparison, Tinkerpop just bails out if you try to export a list property to graphml. */
+    val List = Value("list")
+
     def fromRuntimeClass(clazz: Class[_]): Type.Value = {
       if (clazz.isAssignableFrom(classOf[Boolean]) || clazz.isAssignableFrom(classOf[java.lang.Boolean]))
         Type.Boolean
@@ -26,6 +31,8 @@ package object graphml {
         Type.Double
       else if (clazz.isAssignableFrom(classOf[String]))
         Type.String
+      else if (clazz.isArray || classOf[java.lang.Iterable[_]].isAssignableFrom(clazz) || classOf[IterableOnce[_]].isAssignableFrom(clazz))
+        Type.List
       else
         throw new AssertionError(s"unsupported runtime class `$clazz` - only ${Type.values.mkString("|")} are supported...}")
     }

--- a/formats/src/main/scala/overflowdb/formats/graphml/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/package.scala
@@ -38,6 +38,6 @@ package object graphml {
     }
   }
 
-  private[graphml] case class PropertyContext(name: String, tpe: Type.Value)
+  private[graphml] case class PropertyContext(name: String, tpe: Type.Value, isList: Boolean)
 
 }

--- a/formats/src/main/scala/overflowdb/formats/graphml/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/package.scala
@@ -13,11 +13,6 @@ package object graphml {
     val Double = Value("double")
     val String = Value("string")
 
-    /** Warning: list properties are not natively supported by graphml...
-     *  For our purposes we fake it by encoding it as a `;` separated string - if you import this into a different database, you'll need to parse that separately.
-     *  In comparison, Tinkerpop just bails out if you try to export a list property to graphml. */
-    val List = Value("list")
-
     def fromRuntimeClass(clazz: Class[_]): Type.Value = {
       if (clazz.isAssignableFrom(classOf[Boolean]) || clazz.isAssignableFrom(classOf[java.lang.Boolean]))
         Type.Boolean
@@ -31,8 +26,6 @@ package object graphml {
         Type.Double
       else if (clazz.isAssignableFrom(classOf[String]))
         Type.String
-      else if (clazz.isArray || classOf[java.lang.Iterable[_]].isAssignableFrom(clazz) || classOf[IterableOnce[_]].isAssignableFrom(clazz))
-        Type.List
       else
         throw new AssertionError(s"unsupported runtime class `$clazz` - only ${Type.values.mkString("|")} are supported...}")
     }

--- a/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
@@ -2,7 +2,7 @@ package overflowdb.formats.neo4jcsv
 
 import com.github.tototoshi.csv._
 import overflowdb.Graph
-import overflowdb.formats.{CountAndFiles, ExportResult, Exporter}
+import overflowdb.formats.{CountAndFiles, ExportResult, Exporter, labelsWithNodes}
 
 import java.nio.file.{Files, Path}
 import scala.collection.mutable
@@ -11,6 +11,7 @@ import scala.jdk.OptionConverters.RichOptional
 import scala.util.Using
 
 object Neo4jCsvExporter extends Exporter {
+
   /**
    * Exports OverflowDB Graph to neo4j csv files
    * see https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin/neo4j-admin-import/
@@ -20,11 +21,7 @@ object Neo4jCsvExporter extends Exporter {
    * actually in use *after* traversing all elements.
    * */
   override def runExport(graph: Graph, outputRootDirectory: Path) = {
-    val labelsWithNodes = graph.nodeCountByLabel.asScala.collect {
-      case (label, count) if count > 0 => label
-    }.toSeq
-
-    val CountAndFiles(nodeCount, nodeFiles) = labelsWithNodes.map { label =>
+    val CountAndFiles(nodeCount, nodeFiles) = labelsWithNodes(graph).map { label =>
       exportNodes(graph, label, outputRootDirectory)
     }.reduce(_.plus(_))
     val CountAndFiles(edgeCount, edgeFiles) = exportEdges(graph, outputRootDirectory)

--- a/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
@@ -2,11 +2,11 @@ package overflowdb.formats.neo4jcsv
 
 import com.github.tototoshi.csv._
 import overflowdb.Graph
-import overflowdb.formats.{CountAndFiles, ExportResult, Exporter}
+import overflowdb.formats.{ExportResult, Exporter, labelsWithNodes}
 
 import java.nio.file.{Files, Path}
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.{CollectionHasAsScala, MapHasAsScala}
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.Using
 
@@ -122,12 +122,6 @@ object Neo4jCsvExporter extends Exporter {
     CountAndFiles(count, files)
   }
 
-  private def labelsWithNodes(graph: Graph): Seq[String] = {
-    graph.nodeCountByLabel.asScala.collect {
-      case (label, count) if count > 0 => label
-    }.toSeq
-  }
-
   private def writeSingleLineCsv(outputFile: Path, entries: Seq[Any]): Unit = {
     Using.resource(CSVWriter.open(outputFile.toFile, append = false)) { writer =>
       writer.writeRow(entries)
@@ -140,4 +134,10 @@ object Neo4jCsvExporter extends Exporter {
                                       cypherFile: Path,
                                       dataFileWriter: CSVWriter,
                                       columnDefinitions: ColumnDefinitions)
+
+  case class CountAndFiles(count: Int, files: Seq[Path]) {
+    def plus(other: CountAndFiles): CountAndFiles =
+      CountAndFiles(count + other.count, files ++ other.files)
+  }
+
 }

--- a/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
@@ -19,6 +19,10 @@ object Neo4jCsvExporter extends Exporter {
    * For both nodes and relationships, we first write the data file and to derive the property types from their
    * runtime types. We will write columns for all declared properties, because we only know which ones are
    * actually in use *after* traversing all elements.
+   *
+   * Warning: list properties are not natively supported by graphml...
+   * For our purposes we fake it by encoding it as a `;` separated string - if you import this into a different database, you'll need to parse that separately.
+   * In comparison, Tinkerpop just bails out if you try to export a list property to graphml.
    * */
   override def runExport(graph: Graph, outputRootDirectory: Path) = {
     val CountAndFiles(nodeCount, nodeFiles) = labelsWithNodes(graph).map { label =>

--- a/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
@@ -31,10 +31,10 @@ object Neo4jCsvExporter extends Exporter {
     val CountAndFiles(edgeCount, edgeFiles) = exportEdges(graph, outputRootDirectory)
 
     ExportResult(
-      nodeCount,
-      edgeCount,
+      nodeCount = nodeCount,
+      edgeCount = edgeCount,
       files = nodeFiles ++ edgeFiles,
-      Option(s"""instructions on how to import the exported files into neo4j:
+      additionalInfo = Option(s"""instructions on how to import the exported files into neo4j:
          |```
          |cp $outputRootDirectory/*$DataFileSuffix.csv <neo4j_root>/import
          |cd <neo4j_root>

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -1,6 +1,7 @@
 package overflowdb
 
 import java.nio.file.Path
+import scala.jdk.CollectionConverters.MapHasAsScala
 
 package object formats {
   object Format extends Enumeration {
@@ -18,4 +19,9 @@ package object formats {
       CountAndFiles(count + other.count, files ++ other.files)
   }
 
+  def labelsWithNodes(graph: Graph): Seq[String] = {
+    graph.nodeCountByLabel.asScala.collect {
+      case (label, count) if count > 0 => label
+    }.toSeq
+  }
 }

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -18,4 +18,13 @@ package object formats {
       case (label, count) if count > 0 => label
     }.toSeq
   }
+
+  /**
+   * @return true if the given class is either array or a (subclass of) Java Iterable or Scala IterableOnce
+   */
+  def isList(clazz: Class[_]): Boolean = {
+    clazz.isArray ||
+      classOf[java.lang.Iterable[_]].isAssignableFrom(clazz) ||
+      classOf[IterableOnce[_]].isAssignableFrom(clazz)
+  }
 }

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -1,6 +1,6 @@
 package overflowdb
 
-import java.nio.file.Path
+import scala.jdk.CollectionConverters.MapHasAsScala
 
 package object formats {
   object Format extends Enumeration {
@@ -13,8 +13,9 @@ package object formats {
       byNameLowercase.values.toSeq.map(_.toString.toLowerCase).sorted
   }
 
-  private [formats] case class CountAndFiles(count: Int, files: Seq[Path]) {
-    def plus(other: CountAndFiles): CountAndFiles =
-      CountAndFiles(count + other.count, files ++ other.files)
+  private[formats] def labelsWithNodes(graph: Graph): Seq[String] = {
+    graph.nodeCountByLabel.asScala.collect {
+      case (label, count) if count > 0 => label
+    }.toSeq
   }
 }

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -1,7 +1,6 @@
 package overflowdb
 
 import java.nio.file.Path
-import scala.jdk.CollectionConverters.MapHasAsScala
 
 package object formats {
   object Format extends Enumeration {
@@ -17,11 +16,5 @@ package object formats {
   private [formats] case class CountAndFiles(count: Int, files: Seq[Path]) {
     def plus(other: CountAndFiles): CountAndFiles =
       CountAndFiles(count + other.count, files ++ other.files)
-  }
-
-  def labelsWithNodes(graph: Graph): Seq[String] = {
-    graph.nodeCountByLabel.asScala.collect {
-      case (label, count) if count > 0 => label
-    }.toSeq
   }
 }

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -53,7 +53,7 @@ class GraphMLTests extends AnyWordSpec {
       TestNode.INT_PROPERTY, 11,
       TestNode.STRING_PROPERTY, "stringProp1",
       // TODO add lists back in
-//      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
+      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
 //      TestNode.FUNKY_LIST_PROPERTY, funkyList,
 //      TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
     )

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -9,7 +9,7 @@ import overflowdb.testdomains.simple.{FunkyList, SimpleDomain, TestEdge, TestNod
 import overflowdb.util.DiffTool
 
 import java.nio.file.Paths
-import scala.jdk.CollectionConverters.IterableHasAsJava
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, IterableHasAsJava}
 
 class GraphMLTests extends AnyWordSpec {
 
@@ -65,18 +65,17 @@ class GraphMLTests extends AnyWordSpec {
       val exportResult = GraphMLExporter.runExport(graph, exportRootDirectory.pathAsString)
       exportResult.nodeCount shouldBe 3
       exportResult.edgeCount shouldBe 2
-      val graphMLFile = Seq(exportResult.files)
+      val Seq(graphMLFile) = exportResult.files
 
       // import graphml into new graph, use difftool for round trip of conversion
-      // TODO
-//      val graphFromCsv = SimpleDomain.newGraph()
-//      Neo4jCsvImporter.runImport(graphFromCsv, exportedFiles.filterNot(_.name.contains(CypherFileSuffix)).map(_.toJava.toPath))
-//      val diff = DiffTool.compare(graph, graphFromCsv)
-//      withClue(s"original graph and reimport from csv should be completely equal, but there are differences:\n" +
-//        diff.asScala.mkString("\n") +
-//        "\n") {
-//        diff.size shouldBe 0
-//      }
+      val reimported = SimpleDomain.newGraph()
+      GraphMLImporter.runImport(reimported, graphMLFile)
+      val diff = DiffTool.compare(graph, reimported)
+      withClue(s"original graph and reimport from csv should be completely equal, but there are differences:\n" +
+        diff.asScala.mkString("\n") +
+        "\n") {
+        diff.size shouldBe 0
+      }
     }
   }
 

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -55,7 +55,7 @@ class GraphMLTests extends AnyWordSpec {
       // TODO add lists back in
       TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
 //      TestNode.FUNKY_LIST_PROPERTY, funkyList,
-//      TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
+      TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
     )
 
     node1.addEdge(TestEdge.LABEL, node2, TestEdge.LONG_PROPERTY, Long.MaxValue)

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -1,10 +1,15 @@
 package overflowdb.formats.graphml
 
+import better.files.File
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb.formats.ExportResult
 import overflowdb.testdomains.gratefuldead.GratefulDead
+import overflowdb.testdomains.simple.{FunkyList, SimpleDomain, TestEdge, TestNode}
+import overflowdb.util.DiffTool
 
 import java.nio.file.Paths
+import scala.jdk.CollectionConverters.IterableHasAsJava
 
 class GraphMLTests extends AnyWordSpec {
 
@@ -33,5 +38,86 @@ class GraphMLTests extends AnyWordSpec {
 
     graph.close()
   }
+
+  "Exporter should export valid csv" in {
+    val graph = SimpleDomain.newGraph()
+
+    val node2 = graph.addNode(2, TestNode.LABEL, TestNode.STRING_PROPERTY, "stringProp2")
+    val node3 = graph.addNode(3, TestNode.LABEL, TestNode.INT_PROPERTY, 13)
+
+    // only allows values defined in FunkyList.funkyWords
+    val funkyList = new FunkyList()
+    funkyList.add("apoplectic")
+    funkyList.add("bucolic")
+    val node1 = graph.addNode(1, TestNode.LABEL,
+      TestNode.INT_PROPERTY, 11,
+      TestNode.STRING_PROPERTY, "stringProp1",
+      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
+      TestNode.FUNKY_LIST_PROPERTY, funkyList,
+      TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
+    )
+
+    node1.addEdge(TestEdge.LABEL, node2, TestEdge.LONG_PROPERTY, Long.MaxValue)
+    node2.addEdge(TestEdge.LABEL, node3)
+
+    File.usingTemporaryDirectory(getClass.getName) { exportRootDirectory =>
+      val ExportResult(nodeCount, edgeCount, exportedFiles0, additionalInfo) = GraphMLExporter.runExport(graph, exportRootDirectory.pathAsString)
+      nodeCount shouldBe 3
+      edgeCount shouldBe 2
+      fail("continue here")
+//      val exportedFiles = exportedFiles0.map(_.toFile.toScala)
+//      exportedFiles.size shouldBe 6
+//      exportedFiles.foreach(_.parent shouldBe exportRootDirectory)
+//
+//      // assert csv file contents
+//      val nodeHeaderFile = fuzzyFindFile(exportedFiles, TestNode.LABEL, HeaderFileSuffix)
+//      nodeHeaderFile.contentAsString.trim shouldBe
+//        ":ID,:LABEL,FunkyListProperty:string[],IntListProperty:int[],IntProperty:int,StringListProperty:string[],StringProperty:string"
+//
+//      val nodeDataFileLines = fuzzyFindFile(exportedFiles, TestNode.LABEL, DataFileSuffix).lines.toSeq
+//      nodeDataFileLines.size shouldBe 3
+//      nodeDataFileLines should contain("2,testNode,,,,,stringProp2")
+//      nodeDataFileLines should contain("3,testNode,,,13,,DEFAULT_STRING_VALUE")
+//      nodeDataFileLines should contain("1,testNode,apoplectic;bucolic,21;31;41,11,stringListProp1a;stringListProp1b,stringProp1")
+//
+//      val edgeHeaderFile = fuzzyFindFile(exportedFiles, TestEdge.LABEL, HeaderFileSuffix)
+//      edgeHeaderFile.contentAsString.trim shouldBe ":START_ID,:END_ID,:TYPE,longProperty:long"
+//
+//      val edgeDataFileLines = fuzzyFindFile(exportedFiles, TestEdge.LABEL, DataFileSuffix).lines.toSeq
+//      edgeDataFileLines.size shouldBe 2
+//      edgeDataFileLines should contain(s"1,2,testEdge,${Long.MaxValue}")
+//      edgeDataFileLines should contain(s"2,3,testEdge,${TestEdge.LONG_PROPERTY_DEFAULT}")
+//
+//      fuzzyFindFile(exportedFiles, TestNode.LABEL, CypherFileSuffix).contentAsString shouldBe
+//        """LOAD CSV FROM 'file:/nodes_testNode_data.csv' AS line
+//          |CREATE (:testNode {
+//          |id: toInteger(line[0]),
+//          |FunkyListProperty: toStringList(split(line[2], ";")),
+//          |IntListProperty: toIntegerList(split(line[3], ";")),
+//          |IntProperty: toInteger(line[4]),
+//          |StringListProperty: toStringList(split(line[5], ";")),
+//          |StringProperty: line[6]
+//          |});
+//          |""".stripMargin
+//
+//      fuzzyFindFile(exportedFiles, TestEdge.LABEL, CypherFileSuffix).contentAsString shouldBe
+//        """LOAD CSV FROM 'file:/edges_testEdge_data.csv' AS line
+//          |MATCH (a), (b)
+//          |WHERE a.id = toInteger(line[0]) AND b.id = toInteger(line[1])
+//          |CREATE (a)-[r:testEdge {longProperty: toInteger(line[3])}]->(b);
+//          |""".stripMargin
+//
+//      // import csv into new graph, use difftool for round trip of conversion
+//      val graphFromCsv = SimpleDomain.newGraph()
+//      Neo4jCsvImporter.runImport(graphFromCsv, exportedFiles.filterNot(_.name.contains(CypherFileSuffix)).map(_.toJava.toPath))
+//      val diff = DiffTool.compare(graph, graphFromCsv)
+//      withClue(s"original graph and reimport from csv should be completely equal, but there are differences:\n" +
+//        diff.asScala.mkString("\n") +
+//        "\n") {
+//        diff.size shouldBe 0
+//      }
+    }
+  }
+
 
 }

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -53,8 +53,7 @@ class GraphMLTests extends AnyWordSpec {
       TestNode.INT_PROPERTY, 11,
       TestNode.STRING_PROPERTY, "stringProp1",
       TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
-      // TODO add lists back in
-//      TestNode.FUNKY_LIST_PROPERTY, funkyList,
+      TestNode.FUNKY_LIST_PROPERTY, funkyList,
       TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
     )
 

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -52,62 +52,23 @@ class GraphMLTests extends AnyWordSpec {
     val node1 = graph.addNode(1, TestNode.LABEL,
       TestNode.INT_PROPERTY, 11,
       TestNode.STRING_PROPERTY, "stringProp1",
-      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
-      TestNode.FUNKY_LIST_PROPERTY, funkyList,
-      TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
+      // TODO add lists back in
+//      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
+//      TestNode.FUNKY_LIST_PROPERTY, funkyList,
+//      TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
     )
 
     node1.addEdge(TestEdge.LABEL, node2, TestEdge.LONG_PROPERTY, Long.MaxValue)
     node2.addEdge(TestEdge.LABEL, node3)
 
     File.usingTemporaryDirectory(getClass.getName) { exportRootDirectory =>
-      val ExportResult(nodeCount, edgeCount, exportedFiles0, additionalInfo) = GraphMLExporter.runExport(graph, exportRootDirectory.pathAsString)
-      nodeCount shouldBe 3
-      edgeCount shouldBe 2
-      fail("continue here")
-//      val exportedFiles = exportedFiles0.map(_.toFile.toScala)
-//      exportedFiles.size shouldBe 6
-//      exportedFiles.foreach(_.parent shouldBe exportRootDirectory)
-//
-//      // assert csv file contents
-//      val nodeHeaderFile = fuzzyFindFile(exportedFiles, TestNode.LABEL, HeaderFileSuffix)
-//      nodeHeaderFile.contentAsString.trim shouldBe
-//        ":ID,:LABEL,FunkyListProperty:string[],IntListProperty:int[],IntProperty:int,StringListProperty:string[],StringProperty:string"
-//
-//      val nodeDataFileLines = fuzzyFindFile(exportedFiles, TestNode.LABEL, DataFileSuffix).lines.toSeq
-//      nodeDataFileLines.size shouldBe 3
-//      nodeDataFileLines should contain("2,testNode,,,,,stringProp2")
-//      nodeDataFileLines should contain("3,testNode,,,13,,DEFAULT_STRING_VALUE")
-//      nodeDataFileLines should contain("1,testNode,apoplectic;bucolic,21;31;41,11,stringListProp1a;stringListProp1b,stringProp1")
-//
-//      val edgeHeaderFile = fuzzyFindFile(exportedFiles, TestEdge.LABEL, HeaderFileSuffix)
-//      edgeHeaderFile.contentAsString.trim shouldBe ":START_ID,:END_ID,:TYPE,longProperty:long"
-//
-//      val edgeDataFileLines = fuzzyFindFile(exportedFiles, TestEdge.LABEL, DataFileSuffix).lines.toSeq
-//      edgeDataFileLines.size shouldBe 2
-//      edgeDataFileLines should contain(s"1,2,testEdge,${Long.MaxValue}")
-//      edgeDataFileLines should contain(s"2,3,testEdge,${TestEdge.LONG_PROPERTY_DEFAULT}")
-//
-//      fuzzyFindFile(exportedFiles, TestNode.LABEL, CypherFileSuffix).contentAsString shouldBe
-//        """LOAD CSV FROM 'file:/nodes_testNode_data.csv' AS line
-//          |CREATE (:testNode {
-//          |id: toInteger(line[0]),
-//          |FunkyListProperty: toStringList(split(line[2], ";")),
-//          |IntListProperty: toIntegerList(split(line[3], ";")),
-//          |IntProperty: toInteger(line[4]),
-//          |StringListProperty: toStringList(split(line[5], ";")),
-//          |StringProperty: line[6]
-//          |});
-//          |""".stripMargin
-//
-//      fuzzyFindFile(exportedFiles, TestEdge.LABEL, CypherFileSuffix).contentAsString shouldBe
-//        """LOAD CSV FROM 'file:/edges_testEdge_data.csv' AS line
-//          |MATCH (a), (b)
-//          |WHERE a.id = toInteger(line[0]) AND b.id = toInteger(line[1])
-//          |CREATE (a)-[r:testEdge {longProperty: toInteger(line[3])}]->(b);
-//          |""".stripMargin
-//
-//      // import csv into new graph, use difftool for round trip of conversion
+      val exportResult = GraphMLExporter.runExport(graph, exportRootDirectory.pathAsString)
+      exportResult.nodeCount shouldBe 3
+      exportResult.edgeCount shouldBe 2
+      val graphMLFile = Seq(exportResult.files)
+
+      // import graphml into new graph, use difftool for round trip of conversion
+      // TODO
 //      val graphFromCsv = SimpleDomain.newGraph()
 //      Neo4jCsvImporter.runImport(graphFromCsv, exportedFiles.filterNot(_.name.contains(CypherFileSuffix)).map(_.toJava.toPath))
 //      val diff = DiffTool.compare(graph, graphFromCsv)

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -52,8 +52,8 @@ class GraphMLTests extends AnyWordSpec {
     val node1 = graph.addNode(1, TestNode.LABEL,
       TestNode.INT_PROPERTY, 11,
       TestNode.STRING_PROPERTY, "stringProp1",
+      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
       // TODO add lists back in
-//      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
 //      TestNode.FUNKY_LIST_PROPERTY, funkyList,
       TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
     )

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -17,7 +17,7 @@ class GraphMLTests extends AnyWordSpec {
     val graph = GratefulDead.newGraph()
     graph.nodeCount() shouldBe 0
 
-    GraphMLImport.runImport(graph, Paths.get("src/test/resources/graphml-small.xml"))
+    GraphMLImporter.runImport(graph, Paths.get("src/test/resources/graphml-small.xml"))
     graph.nodeCount() shouldBe 3
     graph.edgeCount() shouldBe 2
 

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -1,4 +1,4 @@
-package overflowdb.formats
+package overflowdb.formats.graphml
 
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -53,7 +53,7 @@ class GraphMLTests extends AnyWordSpec {
       TestNode.INT_PROPERTY, 11,
       TestNode.STRING_PROPERTY, "stringProp1",
       // TODO add lists back in
-      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
+//      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
 //      TestNode.FUNKY_LIST_PROPERTY, funkyList,
       TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
     )

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -51,7 +51,7 @@ class GraphMLTests extends AnyWordSpec {
     funkyList.add("bucolic")
     val node1 = graph.addNode(1, TestNode.LABEL,
       TestNode.INT_PROPERTY, 11,
-      TestNode.STRING_PROPERTY, "stringProp1",
+      TestNode.STRING_PROPERTY, "<stringProp1>",
       TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
       TestNode.FUNKY_LIST_PROPERTY, funkyList,
       TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,

--- a/testdomains/src/main/java/overflowdb/testdomains/simple/TestNodeDb.java
+++ b/testdomains/src/main/java/overflowdb/testdomains/simple/TestNodeDb.java
@@ -102,6 +102,9 @@ public class TestNodeDb extends NodeDb {
         for (Object entry : values) {
           _funkyList.add((String) entry);
         }
+      } else if (value instanceof Iterable) {
+        this._funkyList = new FunkyList();
+        ((Iterable<String>) value).iterator().forEachRemaining(_funkyList::add);
       } else if (value instanceof String) {
         this._funkyList = new FunkyList();
         _funkyList.add((String) value);

--- a/traversal-tests/src/test/scala/overflowdb/traversal/testdomains/gratefuldead/GratefulDead.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/testdomains/gratefuldead/GratefulDead.scala
@@ -1,6 +1,6 @@
 package overflowdb.traversal.testdomains.gratefuldead
 
-import overflowdb.formats.graphml.GraphMLImport
+import overflowdb.formats.graphml.GraphMLImporter
 import java.util
 import overflowdb.traversal.{Traversal, TraversalSource}
 import overflowdb.{Config, Graph}
@@ -21,7 +21,7 @@ object GratefulDead {
   }
 
   def loadData(graph: Graph): Unit =
-    GraphMLImport.runImport(graph, "src/test/resources/grateful-dead.xml")
+    GraphMLImporter.runImport(graph, "src/test/resources/grateful-dead.xml")
 
   def traversal(graph: Graph) = new GratefulDeadTraversalSource(graph)
 }

--- a/traversal-tests/src/test/scala/overflowdb/traversal/testdomains/gratefuldead/GratefulDead.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/testdomains/gratefuldead/GratefulDead.scala
@@ -1,7 +1,6 @@
 package overflowdb.traversal.testdomains.gratefuldead
 
-import overflowdb.formats.GraphMLImport
-
+import overflowdb.formats.graphml.GraphMLImport
 import java.util
 import overflowdb.traversal.{Traversal, TraversalSource}
 import overflowdb.{Config, Graph}


### PR DESCRIPTION
Note: GraphML doesn't natively support list property types, so we fake it by encoding it as a `;` delimited string.
If you import this into a different database, you'll need to parse that separately.
In comparison, Tinkerpop just bails out if you try to export a list property to graphml.