### PR TITLE
drop support for list properties - discard them in export

### DIFF
--- a/formats/src/main/scala/overflowdb/formats/graphml/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/package.scala
@@ -31,6 +31,6 @@ package object graphml {
     }
   }
 
-  private[graphml] case class PropertyContext(name: String, tpe: Type.Value, isList: Boolean)
+  private[graphml] case class PropertyContext(name: String, tpe: Type.Value)
 
 }

--- a/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
@@ -20,9 +20,6 @@ object Neo4jCsvExporter extends Exporter {
    * runtime types. We will write columns for all declared properties, because we only know which ones are
    * actually in use *after* traversing all elements.
    *
-   * Warning: list properties are not natively supported by graphml...
-   * For our purposes we fake it by encoding it as a `;` separated string - if you import this into a different database, you'll need to parse that separately.
-   * In comparison, Tinkerpop just bails out if you try to export a list property to graphml.
    * */
   override def runExport(graph: Graph, outputRootDirectory: Path) = {
     val CountAndFiles(nodeCount, nodeFiles) = labelsWithNodes(graph).map { label =>

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -3,11 +3,11 @@ package overflowdb.formats.graphml
 import better.files.File
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
-import overflowdb.formats.ExportResult
 import overflowdb.testdomains.gratefuldead.GratefulDead
 import overflowdb.testdomains.simple.{FunkyList, SimpleDomain, TestEdge, TestNode}
 import overflowdb.util.DiffTool
 
+import java.lang.System.lineSeparator
 import java.nio.file.Paths
 import scala.jdk.CollectionConverters.{CollectionHasAsScala, IterableHasAsJava}
 
@@ -39,41 +39,74 @@ class GraphMLTests extends AnyWordSpec {
     graph.close()
   }
 
-  "Exporter should export valid csv" in {
-    val graph = SimpleDomain.newGraph()
+  "Exporter should export valid xml" when {
+    "not using (unsupported) list properties" in {
+      val graph = SimpleDomain.newGraph()
 
-    val node2 = graph.addNode(2, TestNode.LABEL, TestNode.STRING_PROPERTY, "stringProp2")
-    val node3 = graph.addNode(3, TestNode.LABEL, TestNode.INT_PROPERTY, 13)
+      val node2 = graph.addNode(2, TestNode.LABEL, TestNode.STRING_PROPERTY, "stringProp2")
+      val node3 = graph.addNode(3, TestNode.LABEL, TestNode.INT_PROPERTY, 13)
 
-    // only allows values defined in FunkyList.funkyWords
-    val funkyList = new FunkyList()
-    funkyList.add("apoplectic")
-    funkyList.add("bucolic")
-    val node1 = graph.addNode(1, TestNode.LABEL,
-      TestNode.INT_PROPERTY, 11,
-      TestNode.STRING_PROPERTY, "<stringProp1>",
-      TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
-      TestNode.FUNKY_LIST_PROPERTY, funkyList,
-      TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
-    )
+      // only allows values defined in FunkyList.funkyWords
+      val funkyList = new FunkyList()
+      funkyList.add("apoplectic")
+      funkyList.add("bucolic")
+      val node1 = graph.addNode(1, TestNode.LABEL,
+        TestNode.INT_PROPERTY, 11,
+        TestNode.STRING_PROPERTY, "<stringProp1>",
+      )
 
-    node1.addEdge(TestEdge.LABEL, node2, TestEdge.LONG_PROPERTY, Long.MaxValue)
-    node2.addEdge(TestEdge.LABEL, node3)
+      node1.addEdge(TestEdge.LABEL, node2, TestEdge.LONG_PROPERTY, Long.MaxValue)
+      node2.addEdge(TestEdge.LABEL, node3)
 
-    File.usingTemporaryDirectory(getClass.getName) { exportRootDirectory =>
-      val exportResult = GraphMLExporter.runExport(graph, exportRootDirectory.pathAsString)
-      exportResult.nodeCount shouldBe 3
-      exportResult.edgeCount shouldBe 2
-      val Seq(graphMLFile) = exportResult.files
+      File.usingTemporaryDirectory(getClass.getName) { exportRootDirectory =>
+        val exportResult = GraphMLExporter.runExport(graph, exportRootDirectory.pathAsString)
+        exportResult.nodeCount shouldBe 3
+        exportResult.edgeCount shouldBe 2
+        val Seq(graphMLFile) = exportResult.files
 
-      // import graphml into new graph, use difftool for round trip of conversion
-      val reimported = SimpleDomain.newGraph()
-      GraphMLImporter.runImport(reimported, graphMLFile)
-      val diff = DiffTool.compare(graph, reimported)
-      withClue(s"original graph and reimport from csv should be completely equal, but there are differences:\n" +
-        diff.asScala.mkString("\n") +
-        "\n") {
-        diff.size shouldBe 0
+        // import graphml into new graph, use difftool for round trip of conversion
+        val reimported = SimpleDomain.newGraph()
+        GraphMLImporter.runImport(reimported, graphMLFile)
+        val diff = DiffTool.compare(graph, reimported)
+        withClue(s"original graph and reimport from graphml should be completely equal, but there are differences:\n" +
+          diff.asScala.mkString("\n") +
+          "\n") {
+          diff.size shouldBe 0
+        }
+      }
+    }
+
+    "using list properties" in {
+      val graph = SimpleDomain.newGraph()
+
+      // will discard the list properties
+      val node1 = graph.addNode(1, TestNode.LABEL,
+        TestNode.INT_PROPERTY, 11,
+        TestNode.STRING_PROPERTY, "<stringProp1>",
+        TestNode.STRING_LIST_PROPERTY, List("stringListProp1a", "stringListProp1b").asJava,
+        TestNode.INT_LIST_PROPERTY, List(21, 31, 41).asJava,
+      )
+
+      File.usingTemporaryDirectory(getClass.getName) { exportRootDirectory =>
+        val exportResult = GraphMLExporter.runExport(graph, exportRootDirectory.pathAsString)
+        exportResult.nodeCount shouldBe 1
+        exportResult.edgeCount shouldBe 0
+        exportResult.additionalInfo.get should include("discarded 2 list properties")
+        val Seq(graphMLFile) = exportResult.files
+
+        // import graphml into new graph, use difftool for round trip of conversion
+        val reimported = SimpleDomain.newGraph()
+        GraphMLImporter.runImport(reimported, graphMLFile)
+        val diff = DiffTool.compare(graph, reimported)
+        val diffString = diff.asScala.mkString(lineSeparator)
+        withClue(s"because the original graph contained two list properties, and those are not supported by graphml, " +
+          s"the exporter drops them. therefor they'll not be part of the reimported graph" +
+          diffString +
+          lineSeparator) {
+          diff.size shouldBe 2
+          diffString should include("IntListProperty")
+          diffString should include("StringListProperty")
+        }
       }
     }
   }


### PR DESCRIPTION
Faking list properties by just appending `[]` to the property key definitions wasn't a good idea.
 It's not supported by the specification, and hence no other tool or db understood our encoding. Worse, some tools completely stop the import.
Now, we discard them in the export and display a warning at the end: `this graph contained X list properties`

With this, the import into both gephi and neo4j works