### PR TITLE
export to graphviz dot format

### DIFF
--- a/formats/src/main/scala/overflowdb/formats/ExporterMain.scala
+++ b/formats/src/main/scala/overflowdb/formats/ExporterMain.scala
@@ -1,6 +1,7 @@
 package overflowdb.formats
 
 import org.slf4j.LoggerFactory
+import overflowdb.formats.dot.DotExporter
 import overflowdb.formats.graphml.GraphMLExporter
 import overflowdb.{EdgeFactory, Graph, NodeFactory}
 import overflowdb.formats.neo4jcsv.Neo4jCsvExporter
@@ -37,6 +38,7 @@ object ExporterMain {
           val exporter: Exporter = format match {
             case Format.Neo4jCsv => Neo4jCsvExporter
             case Format.GraphMl => GraphMLExporter
+            case Format.Dot => DotExporter
           }
           val odbConfig = overflowdb.Config.withoutOverflow.withStorageLocation(inputFile)
           logger.info(s"starting export of graph in $inputFile to storagePath=$outputFile in format=$format")

--- a/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
@@ -43,8 +43,6 @@ object DotExporter extends Exporter {
       }
 
       writeLine("}")
-      writer.flush()
-      writer.close()
     }
 
     ExportResult(
@@ -87,19 +85,4 @@ object DotExporter extends Exporter {
     }
     outputRootDirectory.resolve("export.dot")
   }
-
-  private def encodeListValue(value: AnyRef): String = {
-    value match {
-      case value: Iterable[_] =>
-        value.mkString(";")
-      case value: IterableOnce[_] =>
-        value.iterator.mkString(";")
-      case value: java.lang.Iterable[_] =>
-        value.asScala.mkString(";")
-      case value: Array[_] =>
-        value.mkString(";")
-      case _ => value.toString
-    }
-  }
-
 }

--- a/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
@@ -1,0 +1,104 @@
+package overflowdb.formats.dot
+
+import overflowdb.formats.{ExportResult, Exporter, isList}
+import overflowdb.{Element, Graph, Node}
+
+import java.lang.System.lineSeparator
+import java.nio.file.{Files, Path}
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.{IterableHasAsScala, IteratorHasAsScala, MapHasAsScala}
+import scala.util.Using
+import scala.xml.{PrettyPrinter, XML}
+
+/**
+ * Exports OverflowDB Graph to graphviz dot/gv file
+ *
+ * Note: GraphML doesn't natively support list property types, so we fake it by encoding it as a `;` delimited string.
+ * If you import this into a different database, you'll need to parse that separately.
+ *
+ * https://en.wikipedia.org/wiki/DOT_(graph_description_language)
+ * https://www.graphviz.org/doc/info/lang.html
+ * http://magjac.com/graphviz-visual-editor/
+ * https://www.slideshare.net/albazo/graphiz-using-the-dot-language
+ * */
+object DotExporter extends Exporter {
+
+  override def runExport(graph: Graph, outputRootDirectory: Path) = {
+    val outFile = resolveOutputFile(outputRootDirectory)
+    var nodeCount, edgeCount = 0
+
+    Using.resource(Files.newBufferedWriter(outFile)) { writer =>
+      def writeLine(line: String): Unit = {
+        writer.write(line)
+        writer.newLine()
+      }
+
+      writeLine("digraph {")
+
+      graph.nodes().forEachRemaining { node =>
+        nodeCount += 1
+        writeLine(node2Dot(node))
+      }
+
+      graph.edges().forEachRemaining { edge =>
+        edgeCount += 1
+
+      }
+
+
+      writeLine("}")
+      writer.flush()
+      writer.close()
+    }
+
+    ExportResult(
+      nodeCount = nodeCount,
+      edgeCount = edgeCount,
+      files = Seq(outFile),
+      additionalInfo = None
+    )
+  }
+
+  private def node2Dot(node: Node): String = {
+    s"  ${node.id} [label=${node.label} ${properties2Dot(node.propertiesMap)}]"
+  }
+
+  private def properties2Dot(properties: java.util.Map[String, Object]): String = {
+    properties.asScala.map { case (key, value) =>
+      s"$key=${encodePropertyValue(value)}"
+    }.mkString(" ")
+  }
+
+  private def encodePropertyValue(value: Object): String = {
+    value match {
+      case value: String => s"\"$value\""
+      // TODO other skalar types
+      // TODO all list types
+      case value => value.toString
+    }
+  }
+
+  private def resolveOutputFile(outputRootDirectory: Path): Path = {
+    if (Files.exists(outputRootDirectory)) {
+      assert(Files.isDirectory(outputRootDirectory), s"given output directory `$outputRootDirectory` must be a directory, but isn't...")
+    } else {
+      Files.createDirectories(outputRootDirectory)
+    }
+    outputRootDirectory.resolve("export.dot")
+  }
+
+  private def encodeListValue(value: AnyRef): String = {
+    value match {
+      case value: Iterable[_] =>
+        value.mkString(";")
+      case value: IterableOnce[_] =>
+        value.iterator.mkString(";")
+      case value: java.lang.Iterable[_] =>
+        value.asScala.mkString(";")
+      case value: Array[_] =>
+        value.mkString(";")
+      case _ => value.toString
+    }
+  }
+
+}

--- a/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
@@ -1,14 +1,11 @@
 package overflowdb.formats.dot
 
-import overflowdb.formats.{ExportResult, Exporter, isList, iterableForList}
-import overflowdb.{Element, Graph, Node}
+import overflowdb.formats.{ExportResult, Exporter, iterableForList}
+import overflowdb.{Edge, Graph, Node}
 
-import java.lang.System.lineSeparator
 import java.nio.file.{Files, Path}
-import scala.collection.mutable
-import scala.jdk.CollectionConverters.{IterableHasAsScala, IteratorHasAsScala, MapHasAsScala}
+import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
 import scala.util.Using
-import scala.xml.{PrettyPrinter, XML}
 
 /**
  * Exports OverflowDB Graph to graphviz dot/gv file
@@ -42,6 +39,7 @@ object DotExporter extends Exporter {
 
       graph.edges().forEachRemaining { edge =>
         edgeCount += 1
+        writeLine(edge2Dot(edge))
       }
 
       writeLine("}")
@@ -59,6 +57,10 @@ object DotExporter extends Exporter {
 
   private def node2Dot(node: Node): String = {
     s"  ${node.id} [label=${node.label} ${properties2Dot(node.propertiesMap)}]"
+  }
+
+  private def edge2Dot(edge: Edge): String = {
+    s"  ${edge.outNode.id} -> ${edge.inNode.id} [label=${edge.label} ${properties2Dot(edge.propertiesMap)}]"
   }
 
   private def properties2Dot(properties: java.util.Map[String, Object]): String = {

--- a/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
@@ -1,6 +1,6 @@
 package overflowdb.formats.dot
 
-import overflowdb.formats.{ExportResult, Exporter, isList}
+import overflowdb.formats.{ExportResult, Exporter, isList, iterableForList}
 import overflowdb.{Element, Graph, Node}
 
 import java.lang.System.lineSeparator
@@ -42,9 +42,7 @@ object DotExporter extends Exporter {
 
       graph.edges().forEachRemaining { edge =>
         edgeCount += 1
-
       }
-
 
       writeLine("}")
       writer.flush()
@@ -72,8 +70,9 @@ object DotExporter extends Exporter {
   private def encodePropertyValue(value: Object): String = {
     value match {
       case value: String => s"\"$value\""
-      // TODO other skalar types
-      // TODO all list types
+      case list if iterableForList.isDefinedAt(list) =>
+        val values = iterableForList(list).mkString(";")
+        s"\"$values\""
       case value => value.toString
     }
   }

--- a/formats/src/main/scala/overflowdb/formats/neo4jcsv/ColumnDefinitions.scala
+++ b/formats/src/main/scala/overflowdb/formats/neo4jcsv/ColumnDefinitions.scala
@@ -1,5 +1,7 @@
 package overflowdb.formats.neo4jcsv
 
+import overflowdb.formats.iterableForList
+
 import scala.collection.immutable.ArraySeq
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.IterableHasAsScala

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -1,6 +1,7 @@
 package overflowdb
 
-import scala.jdk.CollectionConverters.MapHasAsScala
+import scala.collection.immutable.ArraySeq
+import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
 
 package object formats {
   object Format extends Enumeration {
@@ -26,5 +27,12 @@ package object formats {
     clazz.isArray ||
       classOf[java.lang.Iterable[_]].isAssignableFrom(clazz) ||
       classOf[IterableOnce[_]].isAssignableFrom(clazz)
+  }
+
+  val iterableForList: PartialFunction[Any, Iterable[_]] = {
+    case it: Iterable[_]           => it
+    case it: IterableOnce[_]       => it.iterator.toSeq
+    case it: java.lang.Iterable[_] => it.asScala
+    case arr: Array[_]             => ArraySeq.unsafeWrapArray(arr)
   }
 }

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -5,7 +5,7 @@ import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
 
 package object formats {
   object Format extends Enumeration {
-    val Neo4jCsv, GraphMl = Value
+    val Neo4jCsv, GraphMl, Dot = Value
 
     lazy val byNameLowercase: Map[String, Format.Value] =
       values.map(format => (format.toString.toLowerCase, format)).toMap

--- a/formats/src/test/scala/overflowdb/formats/dot/DotTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/dot/DotTests.scala
@@ -38,12 +38,17 @@ class DotTests extends AnyWordSpec {
       exportResult.edgeCount shouldBe 2
       val Seq(exportedFile) = exportResult.files
 
-      better.files.File(exportedFile).contentAsString.trim shouldBe
-        s"""digraph {
-           |  2 [label=testNode StringProperty="stringProp2"]
-           |  3 [label=testNode StringProperty="DEFAULT_STRING_VALUE" IntProperty=13]
-           |  1 [label=testNode FunkyListProperty="apoplectic;bucolic" StringProperty="<stringProp1>" StringListProperty="stringListProp1a;stringListProp1b" IntProperty=11 IntListProperty="21;31;41"]
-           |}""".stripMargin.trim
+      val result = better.files.File(exportedFile).contentAsString.trim
+      withClue(s"actual result was: `$result`") {
+        result shouldBe
+          s"""digraph {
+             |  2 [label=testNode StringProperty="stringProp2"]
+             |  3 [label=testNode StringProperty="DEFAULT_STRING_VALUE" IntProperty=13]
+             |  1 [label=testNode FunkyListProperty="apoplectic;bucolic" StringProperty="<stringProp1>" StringListProperty="stringListProp1a;stringListProp1b" IntProperty=11 IntListProperty="21;31;41"]
+             |  2 -> 3 [label=testEdge longProperty=-99]
+             |  1 -> 2 [label=testEdge longProperty=9223372036854775807]
+             |}""".stripMargin.trim
+      }
     }
   }
 

--- a/formats/src/test/scala/overflowdb/formats/dot/DotTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/dot/DotTests.scala
@@ -38,18 +38,12 @@ class DotTests extends AnyWordSpec {
       exportResult.edgeCount shouldBe 2
       val Seq(exportedFile) = exportResult.files
 
-      better.files.File(exportedFile).contentAsString shouldBe
+      better.files.File(exportedFile).contentAsString.trim shouldBe
         s"""digraph {
            |  2 [label=testNode StringProperty="stringProp2"]
            |  3 [label=testNode StringProperty="DEFAULT_STRING_VALUE" IntProperty=13]
-           |  1 [label=testNode FunkyListProperty="apoplectic;bucolic" StringProperty="<stringProp1>" StringListProperty="stringListProp1a;stringListProp1b" IntProperty=11 IntListProperty="21;31;41"
-           |}""".stripMargin
-
-      /** We don't have a dot importer yet (mostly because handling types and lists is difficult and requires
-       * some work in the codegen. For now, we only validate that it's a valid dot file by calling the system
-       * `dot` process. If it's not available, we only issue a warning, i.e. we don't mark the test as failed.
-       **/
-      // TODO warn if `dot` is not available
+           |  1 [label=testNode FunkyListProperty="apoplectic;bucolic" StringProperty="<stringProp1>" StringListProperty="stringListProp1a;stringListProp1b" IntProperty=11 IntListProperty="21;31;41"]
+           |}""".stripMargin.trim
     }
   }
 


### PR DESCRIPTION
Leaving out the importer for now - mostly because dot is untyped... we could generate 
'importFromString' methods for each property in the odb-codegen in the future...

Note: GraphML doesn't natively support list property types, so we fake it by encoding it as a `;` delimited string.

Random links:
* https://en.wikipedia.org/wiki/DOT_(graph_description_language)
* https://www.graphviz.org/doc/info/lang.html
* http://magjac.com/graphviz-visual-editor/