### PR TITLE
TraversalSource:id should default node type to `Node`

### DIFF
--- a/traversal-tests/src/test/scala/overflowdb/traversal/TraversalSourceTest.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/TraversalSourceTest.scala
@@ -3,31 +3,57 @@ package overflowdb.traversal
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb._
-import overflowdb.traversal.testdomains.simple.{SimpleDomain, Thing}
+import overflowdb.traversal.testdomains.simple.Thing.Properties.Name
+import overflowdb.traversal.testdomains.simple.{Connection, SimpleDomain, Thing}
 
 class TraversalSourceTest extends AnyWordSpec {
 
-  "property lookup with and without indexes" in {
+  "id starter step" when {
+
+    "cast to given node type" in new Fixture {
+      def thingViaId = traversal.id[Thing](one.id)
+      thingViaId.out.next() shouldBe two1
+
+      // `.outV` is only available on Traversal[Edge] (via EdgeTraversal)
+      assertCompiles("thingViaId.out")
+      assertDoesNotCompile("thingViaId.outV")
+    }
+
+    "default to `Node` if no type parameter given" in new Fixture {
+      def thingViaId = traversal.id(one.id)
+      thingViaId.out.next() shouldBe two1
+
+      // `.outV` is only available on Traversal[Edge] (via EdgeTraversal)
+      assertCompiles("thingViaId.out")
+      assertDoesNotCompile("thingViaId.outV")
+    }
+  }
+
+  "property lookup with and without indexes" in new Fixture {
+    verifyTraversalResults()
+    graph.indexManager.createNodePropertyIndex(Name.name)
+    verifyTraversalResults()
+  }
+
+  private class Fixture {
     val graph = SimpleDomain.newGraph
-    import Thing.Properties.Name
 
     val one = graph + (Thing.Label, Name.of("one"))
     val two1 = graph + (Thing.Label, Name.of("two"))
     val two2 = graph + (Thing.Label, Name.of("two"))
+    one.addEdge(Connection.Label, two1)
 
-    def verify() = {
-      TraversalSource(graph).has(Name.of("one")).toSetMutable shouldBe Set(one)
-      TraversalSource(graph).has(Name.of("two")).toSetMutable shouldBe Set(two1, two2)
-      TraversalSource(graph).has(Name.of("unknown")).toSetMutable shouldBe Set.empty
+    def traversal = SimpleDomain.traversal(graph)
 
-      TraversalSource(graph).labelAndProperty(Thing.Label, Name.of("two")).toSetMutable shouldBe Set(two1, two2)
-      TraversalSource(graph).labelAndProperty(Thing.Label, Name.of("unknown")).toSetMutable shouldBe Set.empty
-      TraversalSource(graph).labelAndProperty("unknown", Name.of("two")).toSetMutable shouldBe Set.empty
+    def verifyTraversalResults() = {
+      traversal.has(Name.of("one")).toSetMutable shouldBe Set(one)
+      traversal.has(Name.of("two")).toSetMutable shouldBe Set(two1, two2)
+      traversal.has(Name.of("unknown")).toSetMutable shouldBe Set.empty
+
+      traversal.labelAndProperty(Thing.Label, Name.of("two")).toSetMutable shouldBe Set(two1, two2)
+      traversal.labelAndProperty(Thing.Label, Name.of("unknown")).toSetMutable shouldBe Set.empty
+      traversal.labelAndProperty("unknown", Name.of("two")).toSetMutable shouldBe Set.empty
     }
 
-    verify()
-    graph.indexManager.createNodePropertyIndex(Name.name)
-    verify()
   }
-
 }

--- a/traversal/src/main/scala/overflowdb/traversal/DefaultsToNode.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/DefaultsToNode.scala
@@ -13,7 +13,7 @@ object DefaultsToNode {
   implicit def overrideDefault[A]: DefaultsToNode[A] =
     new DefaultsToNode[A]
 
-  implicit def default: DefaultsToNode[Node] =
+  implicit val default: DefaultsToNode[Node] =
     new DefaultsToNode[Node]
 
 }

--- a/traversal/src/main/scala/overflowdb/traversal/DefaultsToNode.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/DefaultsToNode.scala
@@ -1,0 +1,20 @@
+package overflowdb.traversal
+
+import overflowdb.Node
+
+/**
+ * Typeclass to prevent type inferencer to default to `Nothing` if no type parameter is given
+ * used e.g. for `NodeTypeStarters:id`
+ * */
+sealed class DefaultsToNode[A]
+
+object DefaultsToNode {
+
+  implicit def overrideDefault[A]: DefaultsToNode[A] =
+    new DefaultsToNode[A]
+
+  implicit def default: DefaultsToNode[Node] =
+    new DefaultsToNode[Node]
+
+}
+

--- a/traversal/src/main/scala/overflowdb/traversal/TraversalSource.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/TraversalSource.scala
@@ -7,14 +7,11 @@ class TraversalSource(graph: Graph) {
   def all: Traversal[Node] =
     Traversal(graph.nodes())
 
-  def id(id: Long): Traversal[Node] =
-    Traversal(graph.node(id))
+  def id[NodeType : DefaultsToNode](id: Long): Traversal[NodeType] =
+    Traversal(graph.node(id)).cast[NodeType]
 
-  def idTyped[A <: Node](id: Long): Traversal[A] =
-    Traversal(graph.node(id)).cast[A]
-
-  def ids(ids: Long*): Traversal[Node] =
-    Traversal(graph.nodes(ids: _*))
+  def ids[NodeType : DefaultsToNode](ids: Long*): Traversal[NodeType] =
+    Traversal(graph.nodes(ids: _*)).cast[NodeType]
 
   def label(label: String): Traversal[Node] =
     Traversal(graph.nodes(label))


### PR DESCRIPTION
rather than `Nothing` as before. Otherwise, this invalid traversal
would compile: `graph.id(0).outV`. Now, we get a compiler error.

Re https://github.com/joernio/joern/issues/1367