### PR TITLE
add `union` step

### DIFF
--- a/traversal-tests/src/test/scala/overflowdb/traversal/TraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/TraversalTests.scala
@@ -123,6 +123,16 @@ class TraversalTests extends AnyWordSpec {
     traversal.l shouldBe Seq(artist1, artist2)
   }
 
+  ".union step allows to aggregate multiple steps into one traversal" in {
+    def unionTrav = Traversal.fromSingle(center).out.union(_.out, _.in)
+    unionTrav.toSet shouldBe Set(l2, center, r2)
+    unionTrav.l.sortBy(_.property(Thing.Properties.Name)) shouldBe List(center, center, l2, r2)
+
+    // ensure that types are being preserved...
+    val verifyIsNodeTraversal: Traversal[Node] = unionTrav
+    val verifyIsThingTraversal: Traversal[Thing] = Traversal.fromSingle(center).union(_.followedBy, _.followedBy)
+  }
+
   ".aggregate step stores all objects at this point into a given collection" in {
      val buffer = mutable.ArrayBuffer.empty[Thing]
      center.start.followedBy.aggregate(buffer).followedBy.iterate()

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -129,12 +129,13 @@ class Traversal[+A](elements: IterableOnce[A])
    *       _.has("someProperty"))
    * }}} */
   @Doc(info = "only preserves elements for which _at least one of_ the given traversals has at least one result")
-  def or(traversals: (Traversal[A] => Traversal[_])*): Traversal[A] =
+  def or(traversals: (Traversal[A] => Traversal[_])*): Traversal[A] = {
     filter { (a: A) =>
       traversals.exists { trav =>
         trav(Traversal.fromSingle(a)).hasNext
       }
     }
+  }
 
   /** only preserves elements for which _all of_ the given traversals have at least one result
    * Works for arbitrary amount of 'AND' traversals.
@@ -143,12 +144,28 @@ class Traversal[+A](elements: IterableOnce[A])
    *        _.has("someProperty"))
    * }}} */
   @Doc(info = "only preserves elements for which _all of_ the given traversals have at least one result")
-  def and(traversals: (Traversal[A] => Traversal[_])*): Traversal[A] =
+  def and(traversals: (Traversal[A] => Traversal[_])*): Traversal[A] = {
     filter { (a: A) =>
       traversals.forall { trav =>
         trav(Traversal.fromSingle(a)).hasNext
       }
     }
+  }
+
+  /**
+   * union step from the current point
+   *
+   * @param traversals to be executed from here, results are being aggregated/summed/unioned
+   * @example {{{
+   *   .union(_.out, _.in)
+   * }}}
+   */
+  @Doc(info = "union/sum/aggregate given traversals from the current point")
+  def union[B](traversals: (Traversal[A] => Traversal[B])*): Traversal[B] = {
+    flatMap { (a: A) =>
+      traversals.flatMap(_.apply(Traversal.fromSingle(a)))
+    }
+  }
 
   /** Repeat the given traversal
    *


### PR DESCRIPTION
execute traversals from current point, results are being aggregated/summed/unioned

use case e.g.
```
  // before:
  cpg.typeDecl.external.fullName.toSet ++ cpg.typeDecl.internal.fullName.toSet
  // with union:
  cpg.typeDecl.union(_.external, _.internal).fullName.toSet
```