### PR TITLE
Allow more simple constructions to use the index

### DIFF
--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -21,7 +21,7 @@ public final class Graph implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(Graph.class);
 
   protected final AtomicLong currentId = new AtomicLong(-1L);
-  protected final NodesList nodes = new NodesList();
+  final NodesList nodes = new NodesList();
   public final IndexManager indexManager = new IndexManager(this);
   private final Config config;
   private boolean closed = false;

--- a/traversal/src/main/scala/overflowdb/traversal/InitialTraversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/InitialTraversal.scala
@@ -1,0 +1,38 @@
+package overflowdb.traversal
+
+import overflowdb.Graph
+
+class InitialTraversal[+A <: overflowdb.Node] private (graph: Graph,
+                                                       label: String,
+                                                       iter: ArrayListIter[A])
+    extends Traversal[A](iter) {
+
+  def getByIndex(key: String, value: Any): Traversal[A] = {
+    if (iter.idx == 0 && graph.indexManager.isIndexed(key)) {
+      val nodes = graph.indexManager.lookup(key, value)
+      Traversal.from(nodes.iterator()).asInstanceOf[Traversal[A]]
+    } else {
+      null
+    }
+  }
+}
+
+object InitialTraversal {
+  def from[A](graph: Graph, label: String): InitialTraversal[A] = {
+    new InitialTraversal(
+      graph,
+      label,
+      new ArrayListIter[A](graph.nodes.nodesByLabel(label).asInstanceOf[java.util.ArrayList[A]]))
+  }
+}
+private[overflowdb] class ArrayListIter[+T](arr: java.util.ArrayList[T]) extends Iterator[T] {
+  private[overflowdb] var idx = 0
+
+  override def hasNext: Boolean = idx < arr.size()
+
+  override def next(): T = {
+    if (!hasNext) throw new NoSuchElementException()
+    idx = idx + 1
+    arr.get(idx - 1)
+  }
+}


### PR DESCRIPTION
add new Traversal subclass for initial traversals over the graph. Idea is that cpg.method.fullNameExact should use the index instead iterating over everything. Hence, cpg.method needs to be the new type of traversal, and the implicit .fullNameExact needs to use reflection to check whether it can potentially use the index. However, we can only do this if the iterator itself is virgin, e.g. val trav = cpg.method; trav.next; trav.fullNameExact(...) cannot use the index.

The way this will look like in the implicit is 
```
  def fullNameExact(value: String): Traversal[NodeType] = {
val fast = traversal match{
case init: InitialTraversal[A] => init.getByIndex("FULL_NAME", fn)
case _ => null
}
if(fast != null) fast  else  traversal.filter { node => node.fullName == value }
}
```

The main reason is that lots of users -- especially our internal users who write framework code -- can't be convinced to consistently use the TraversalSource classes in their code. It always looks like `cpg.method.fullName("foo")`.

Follow-ups to make this useful:
1. NodeStarters must generate the new InitialTraversal
2. overflowdb-codegen must emit the code to check this.