### PR TITLE
StringPropertyFilter.exactMultiple helper for varargs queries

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/InitialTraversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/InitialTraversal.scala
@@ -7,9 +7,11 @@ class InitialTraversal[+A <: overflowdb.Node] private (graph: Graph,
                                                        iter: ArrayListIter[A])
     extends Traversal[A](iter) {
 
+  // we can only do this if the iterator itself is virgin, e.g. `val trav = cpg.method; trav.next; trav.fullNameExact(...)` cannot use the index
+  def canUseIndex(key: String): Boolean = iter.idx == 0 && graph.indexManager.isIndexed(key)
+
   def getByIndex(key: String, value: Any): Option[Traversal[A]] = {
-    // we can only do this if the iterator itself is virgin, e.g. `val trav = cpg.method; trav.next; trav.fullNameExact(...)` cannot use the index
-    if (iter.idx == 0 && graph.indexManager.isIndexed(key)) {
+    if (canUseIndex(key)) {
       val nodes = graph.indexManager.lookup(key, value)
       Some(Traversal.from(nodes.iterator()).label(label).cast[A])
     } else {

--- a/traversal/src/main/scala/overflowdb/traversal/filter/StringPropertyFilter.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/filter/StringPropertyFilter.scala
@@ -1,7 +1,9 @@
 package overflowdb.traversal.filter
 
-import java.util.regex.PatternSyntaxException
 import overflowdb.traversal.Traversal
+
+import java.util.regex.PatternSyntaxException
+import scala.collection.mutable
 import scala.util.matching.Regex
 
 object StringPropertyFilter {
@@ -39,8 +41,8 @@ object StringPropertyFilter {
   }
 
   /** compiles given string into a Regex which can be reused
-   * prefixes given string with `(?s)` to enable multi line matching
-   */
+    * prefixes given string with `(?s)` to enable multi line matching
+    */
   def regexpCompile(regexp: String): Regex =
     try {
       s"(?s)$regexp".r
@@ -67,5 +69,37 @@ object StringPropertyFilter {
   def endsWith[NodeType](trav: Traversal[NodeType])(accessor: NodeType => String,
                                                     value: String): Traversal[NodeType] =
     trav.filter(accessor(_).endsWith(value))
+
+  def exactMultiple[NodeType, ValueType](traversal: Traversal[NodeType],
+                                         accessor: NodeType => Option[ValueType],
+                                         needles: Seq[ValueType],
+                                         indexName: String): Traversal[NodeType] = {
+    if (needles.isEmpty)
+      return Traversal.empty
+
+    traversal match {
+      case init: overflowdb.traversal.InitialTraversal[NodeType] if init.canUseIndex(indexName) =>
+        needles
+          .to(Traversal)
+          .flatMap(needle => init.getByIndex(indexName, needle).get)
+      case _ =>
+        var iteration = 0
+        var needleSet: mutable.HashSet[ValueType] = null
+
+        traversal.filter { node =>
+          iteration += 1
+
+          accessor(node).exists { value =>
+            // Creating and accessing HashSets is expensive, so just sequentially scan needles for the first iteration.
+            // (A max of 1 iteration happens regularly with .where/.whereNot clauses.)
+            if (iteration >= 2 && needleSet == null)
+              needleSet = needles.to(mutable.HashSet)
+
+            if (needleSet == null) needles.contains(value)
+            else needleSet.contains(value)
+          }
+        }
+    }
+  }
 
 }

--- a/traversal/src/main/scala/overflowdb/traversal/filter/StringPropertyFilter.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/filter/StringPropertyFilter.scala
@@ -92,6 +92,8 @@ object StringPropertyFilter {
           accessor(node).exists { value =>
             // Creating and accessing HashSets is expensive, so just sequentially scan needles for the first iteration.
             // (A max of 1 iteration happens regularly with .where/.whereNot clauses.)
+            // Note: .contains is faster even for very small sets (if it's called often enough) so we DON'T want a lower
+            // bound of needles.size on this condition
             if (iteration >= 2 && needleSet == null)
               needleSet = needles.to(mutable.HashSet)
 


### PR DESCRIPTION
We discussed the bad performance of the varargs queries, so here's my attempt to fix that. But I haven't actually witnessed performance problems so this is mostly based on assumptions.

- use index if possible
- use a mutable HashSet instead of immutable
- Lazily create the HashSet only on the second iteration. Definitely a win when there's zero iterations. Since single-iteration is relatively common with `.where` and friends it seemed worth it to do delay set creation a bit more and take the potential hit of a single sequential scan.
- I thought about not using sets at all when we only have very few values to search for but some small bit of microbenchmarking convinced me that's a bad idea. 