### PR TITLE
fix NPE in NodesList, also fix race condition

### DIFF
--- a/core/src/main/java/overflowdb/util/NodesList.java
+++ b/core/src/main/java/overflowdb/util/NodesList.java
@@ -94,6 +94,16 @@ public class NodesList {
     return size;
   }
 
+  private TMap<String, ArrayList<Node>> getNodesByLabel() {
+    TMap<String, ArrayList<Node>> nodesByLabel = this.nodesByLabel;
+    if (nodesByLabel != null) {
+      return nodesByLabel;
+    } else {
+      initialiseNodesByLabel();
+      return getNodesByLabel();
+    }
+  }
+
   private synchronized void initialiseNodesByLabel(){
     if (nodesByLabel == null) {
       TMap<String, ArrayList<Node>> tmp = new THashMap<>();
@@ -112,7 +122,7 @@ public class NodesList {
   }
 
   public ArrayList<Node> nodesByLabel(String label) {
-    if (nodesByLabel == null) initialiseNodesByLabel();
+    TMap<String, ArrayList<Node>> nodesByLabel = getNodesByLabel();
     ArrayList<Node> nodelist = nodesByLabel.get(label);
     if (nodelist == null){
       nodelist = new ArrayList<>();
@@ -122,7 +132,7 @@ public class NodesList {
   }
 
   public Set<String> nodeLabels() {
-    if (nodesByLabel == null) initialiseNodesByLabel();
+    TMap<String, ArrayList<Node>> nodesByLabel = getNodesByLabel();
     Set<String> ret = new HashSet<>(nodesByLabel.size());
     nodesByLabel.entrySet().forEach(entry -> {
       if (!entry.getValue().isEmpty()) {
@@ -210,6 +220,7 @@ public class NodesList {
 
   /** cardinality of nodes for given label */
   public int cardinality(String label) {
+    TMap<String, ArrayList<Node>> nodesByLabel = getNodesByLabel();
     if (nodesByLabel.containsKey(label))
       return nodesByLabel.get(label).size();
     else


### PR DESCRIPTION
Introduced by an optimisation :tm: in
https://github.com/ShiftLeftSecurity/overflowdb/pull/180, removing
a node would result in setting `nodesList = null`. Not all places that
accessed nodesList checked for that, resulting in
a NullPointerException. That's fixed now.

Also fixes a race condition, e.g. triggered by "one thread removes a node and
a different thread gets the nodes". The fix only works with a separate
reference and doesn't add extra `synchronized` blocks.