### PR TITLE
try to fix ConcurrentModificationException

### DIFF
--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -26,7 +26,7 @@ public final class Graph implements AutoCloseable {
   final NodesList nodes = new NodesList();
   public final IndexManager indexManager = new IndexManager(this);
   private final Config config;
-  private boolean closed = false;
+  private volatile boolean closed = false;
 
   protected final Map<String, NodeFactory> nodeFactoryByLabel;
   protected final Map<String, EdgeFactory> edgeFactoryByLabel;
@@ -151,7 +151,7 @@ public final class Graph implements AutoCloseable {
 
   private Node addNodeInternal(long id, String label, Object... keyValues) {
     if (isClosed()) {
-      throw new IllegalStateException("cannot add more elements, graph is closed");
+      throw new AssertionError("graph is closed - no more mutation allowed");
     }
     final NodeRef node = createNode(id, label, keyValues);
     nodes.add(node);
@@ -167,7 +167,7 @@ public final class Graph implements AutoCloseable {
   }
 
   private NodeRef createNode(final long idValue, final String label, final Object... keyValues) {
-    if (closed) {
+    if (isClosed()) {
       throw new AssertionError("graph is closed - no more mutation allowed");
     }
     if (!nodeFactoryByLabel.containsKey(label)) {

--- a/core/src/main/java/overflowdb/util/NodesList.java
+++ b/core/src/main/java/overflowdb/util/NodesList.java
@@ -142,7 +142,7 @@ public class NodesList {
     return ret;
   }
 
-  public Iterator<Node> iterator() {
+  public synchronized Iterator<Node> iterator() {
     return new NodesIterator(Arrays.copyOf(nodes, nodes.length));
   }
 
@@ -159,8 +159,8 @@ public class NodesList {
     }
   }
 
-  /** trims down internal collections to just about the necessary size, in order to allow the remainder to be
-   * garbage collected */
+  /** Trims down internal collections to just about the necessary size, in order to allow the remainder to be
+   * garbage collected. Creates a new `nodes` array which contains all existing nodes.  */
   synchronized void compact() {
     final ArrayList<Node> newNodes = new ArrayList<>(size);
     Iterator<Node> iter = iterator();


### PR DESCRIPTION
We ran into a random ConcurrentModificationException:

```
joern-export --repr=all --format=graphml cpg.bin

Exception in thread "main" java.util.ConcurrentModificationException
  at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1661)
  at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
  at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
  at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
  at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
  at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
  at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
  at overflowdb.storage.NodesWriter.writeAndClearBatched(NodesWriter.java:41)
  at overflowdb.ReferenceManager.clearAllReferences(ReferenceManager.java:155)
  at overflowdb.Graph.shutdownNow(Graph.java:233)
  at overflowdb.Graph.close(Graph.java:219)
  at io.shiftleft.codepropertygraph.generated.Cpg.close(Cpg.scala:63)
  at scala.util.Using$Releasable$AutoCloseableIsReleasable$.release(Using.scala:391)
  at scala.util.Using$Releasable$AutoCloseableIsReleasable$.release(Using.scala:390)
  at scala.util.Using$.resource(Using.scala:267)
  at io.joern.joerncli.JoernExport$.$anonfun$new$5(JoernExport.scala:63)
```

I.e. the graph was modified while it was in shutdown.
The reported error doesn't tell us exactly what kind of modification
happened, so I went through all places and found only one that wasn't
synchronized on the NodesList instance. I also added `volatile` to the
`Graph.closed` flag, not sure if this helps...