### PR TITLE
GraphSON 3.0 Support

### DIFF
--- a/formats/build.sbt
+++ b/formats/build.sbt
@@ -5,6 +5,7 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % "2.1.0",
   ("com.github.pathikrit" %% "better-files" % "3.9.1" % Test).cross(CrossVersion.for3Use2_13),
   "com.github.scopt" %% "scopt" % "4.1.0",
+  "io.spray" %% "spray-json" % "1.3.6" // same JSON parser as solidity2cpg
 )
 scalacOptions ++= Seq("-deprecation:false")
 

--- a/formats/build.sbt
+++ b/formats/build.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % "2.1.0",
   ("com.github.pathikrit" %% "better-files" % "3.9.1" % Test).cross(CrossVersion.for3Use2_13),
   "com.github.scopt" %% "scopt" % "4.1.0",
-  "io.spray" %% "spray-json" % "1.3.6" // same JSON parser as solidity2cpg
+  "io.spray" %% "spray-json" % "1.3.6"
 )
 scalacOptions ++= Seq("-deprecation:false")
 

--- a/formats/src/main/scala/overflowdb/formats/ExporterMain.scala
+++ b/formats/src/main/scala/overflowdb/formats/ExporterMain.scala
@@ -37,8 +37,8 @@ object ExporterMain {
 
           val exporter: Exporter = format match {
             case Format.Neo4jCsv => Neo4jCsvExporter
-            case Format.GraphMl => GraphMLExporter
-            case Format.GraphSon => GraphSONExporter
+            case Format.GraphML => GraphMLExporter
+            case Format.GraphSON => GraphSONExporter
             case Format.Dot => DotExporter
           }
           val odbConfig = overflowdb.Config.withoutOverflow.withStorageLocation(inputFile)

--- a/formats/src/main/scala/overflowdb/formats/ExporterMain.scala
+++ b/formats/src/main/scala/overflowdb/formats/ExporterMain.scala
@@ -3,6 +3,7 @@ package overflowdb.formats
 import org.slf4j.LoggerFactory
 import overflowdb.formats.dot.DotExporter
 import overflowdb.formats.graphml.GraphMLExporter
+import overflowdb.formats.graphson.GraphSONExporter
 import overflowdb.formats.neo4jcsv.Neo4jCsvExporter
 import overflowdb.{EdgeFactory, Graph, NodeFactory}
 import scopt.OParser
@@ -37,6 +38,7 @@ object ExporterMain {
           val exporter: Exporter = format match {
             case Format.Neo4jCsv => Neo4jCsvExporter
             case Format.GraphMl => GraphMLExporter
+            case Format.GraphSon => GraphSONExporter
             case Format.Dot => DotExporter
           }
           val odbConfig = overflowdb.Config.withoutOverflow.withStorageLocation(inputFile)

--- a/formats/src/main/scala/overflowdb/formats/ImporterMain.scala
+++ b/formats/src/main/scala/overflowdb/formats/ImporterMain.scala
@@ -2,6 +2,7 @@ package overflowdb.formats
 
 import org.slf4j.LoggerFactory
 import overflowdb.formats.graphml.GraphMLImporter
+import overflowdb.formats.graphson.GraphSONImporter
 import overflowdb.formats.neo4jcsv.Neo4jCsvImporter
 import overflowdb.{EdgeFactory, Graph, NodeFactory}
 import scopt.OParser
@@ -35,6 +36,7 @@ object ImporterMain extends App {
           val importer: Importer = format match {
             case Format.Neo4jCsv => Neo4jCsvImporter
             case Format.GraphMl => GraphMLImporter
+            case Format.GraphSon => GraphSONImporter
           }
           val odbConfig = overflowdb.Config.withoutOverflow.withStorageLocation(outputFile)
           Using.resource(

--- a/formats/src/main/scala/overflowdb/formats/ImporterMain.scala
+++ b/formats/src/main/scala/overflowdb/formats/ImporterMain.scala
@@ -35,8 +35,8 @@ object ImporterMain extends App {
 
           val importer: Importer = format match {
             case Format.Neo4jCsv => Neo4jCsvImporter
-            case Format.GraphMl => GraphMLImporter
-            case Format.GraphSon => GraphSONImporter
+            case Format.GraphML => GraphMLImporter
+            case Format.GraphSON => GraphSONImporter
           }
           val odbConfig = overflowdb.Config.withoutOverflow.withStorageLocation(outputFile)
           Using.resource(

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
@@ -28,13 +28,12 @@ object GraphSONExporter extends Exporter {
     val nodeEntries = graph
       .nodes()
       .asScala
-      .map(
-        node =>
-          Vertex(
-            LongValue(node.id),
-            node.label,
-            propertyEntry(node, propertyId, "g:VertexProperty")
-        ))
+      .map(node =>
+        Vertex(
+          LongValue(node.id),
+          node.label,
+          propertyEntry(node, propertyId, "g:VertexProperty")
+      ))
       .toSeq
     val edgeEntries = graph
       .edges()

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
@@ -1,0 +1,97 @@
+package overflowdb.formats.graphson
+
+import overflowdb.formats._
+import overflowdb.{Element, Graph}
+
+import java.nio.file.{Files, Path}
+import java.util.concurrent.atomic.AtomicInteger
+import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsScala}
+import overflowdb.formats.graphson.GraphSONProtocol._
+import spray.json._
+
+object GraphSONExporter extends Exporter {
+
+  override def runExport(graph: Graph, outputRootDirectory: Path): ExportResult = {
+    val outFile = resolveOutputFile(outputRootDirectory)
+    // OverflowDB only stores IDs on nodes. GraphSON requires IDs on properties and edges too
+    // so we add them synthetically
+    val propertyId = new AtomicInteger(0)
+    val edgeId = new AtomicInteger(0)
+
+    val nodeEntries = graph
+      .nodes()
+      .asScala
+      .map(node => Vertex(LongValue(node.id), node.label, vertexProperties(node, propertyId)))
+      .toSeq
+    val edgeEntries = graph
+      .edges()
+      .asScala
+      .map { edge =>
+        val inNode = edge.inNode()
+        val outNode = edge.outNode()
+        Edge(LongValue(edgeId.getAndIncrement),
+             edge.label,
+             inNode.label,
+             outNode.label,
+             LongValue(inNode.id),
+             LongValue(outNode.id),
+             edgeProperties(edge, propertyId))
+      }
+      .toSeq
+    val graphSON = GraphSON(GraphSONElements(nodeEntries, edgeEntries))
+    val json = graphSON.toJson
+    writeFile(outFile, json.prettyPrint)
+
+    ExportResult(
+      nodeCount = nodeEntries.size,
+      edgeCount = edgeEntries.size,
+      files = Seq(outFile),
+      Option.empty
+    )
+  }
+
+  def vertexProperties(
+      element: Element,
+      propertyId: AtomicInteger
+  ): Map[String, VertexProperty] = {
+    element.propertiesMap.asScala.map {
+      case (propertyName, propertyValue) =>
+        propertyName -> VertexProperty(LongValue(propertyId.getAndIncrement()),
+                                       valueEntry(propertyValue))
+    }.toMap
+  }
+
+  def edgeProperties(
+      element: Element,
+      propertyId: AtomicInteger
+  ): Map[String, Property] = {
+    element.propertiesMap.asScala.map {
+      case (propertyName, propertyValue) =>
+        propertyName -> Property(LongValue(propertyId.getAndIncrement()), valueEntry(propertyValue))
+    }.toMap
+  }
+
+  def valueEntry(propertyValue: Any): PropertyValue = {
+    // Other types require explicit type definitions to be interpreted other than string or bool
+    propertyValue match {
+      case x: Seq[_]  => ListValue(x.map(valueEntry))
+      case x: Boolean => BooleanValue(x)
+      case x: String  => StringValue(x)
+      case x: Double  => DoubleValue(x)
+      case x: Float   => FloatValue(x)
+      case x: Int     => IntValue(x)
+      case x: Long    => LongValue(x)
+    }
+  }
+
+  private def resolveOutputFile(outputRootDirectory: Path): Path = {
+    if (Files.exists(outputRootDirectory)) {
+      assert(Files.isDirectory(outputRootDirectory),
+             s"given output directory `$outputRootDirectory` must be a directory, but isn't...")
+    } else {
+      Files.createDirectories(outputRootDirectory)
+    }
+    outputRootDirectory.resolve("export.graphson")
+  }
+
+}

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
@@ -1,15 +1,13 @@
 package overflowdb.formats.graphson
 
 import overflowdb.formats._
+import overflowdb.formats.graphson.GraphSONProtocol._
 import overflowdb.{Element, Graph}
+import spray.json._
 
 import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic.AtomicInteger
-import scala.jdk.CollectionConverters.{CollectionHasAsScala, IteratorHasAsScala, MapHasAsScala}
-import overflowdb.formats.graphson.GraphSONProtocol._
-import spray.json._
-
-import java.util
+import scala.jdk.CollectionConverters.{IterableHasAsScala, IteratorHasAsScala, MapHasAsScala}
 
 /**
   * Exports OverflowDB graph to GraphSON 3.0
@@ -80,14 +78,16 @@ object GraphSONExporter extends Exporter {
   def valueEntry(propertyValue: Any): PropertyValue = {
     // Other types require explicit type definitions to be interpreted other than string or bool
     propertyValue match {
-      case x: Array[_]     => ListValue(x.map(valueEntry))
-      case x: util.List[_] => ListValue(x.asScala.map(valueEntry).toArray)
-      case x: Boolean      => BooleanValue(x)
-      case x: String       => StringValue(x)
-      case x: Double       => DoubleValue(x)
-      case x: Float        => FloatValue(x)
-      case x: Int          => IntValue(x)
-      case x: Long         => LongValue(x)
+      case x: Array[_]              => ListValue(x.map(valueEntry))
+      case x: Iterable[_]           => ListValue(x.map(valueEntry).toArray)
+      case x: IterableOnce[_]       => ListValue(x.iterator.map(valueEntry).toArray)
+      case x: java.lang.Iterable[_] => ListValue(x.asScala.map(valueEntry).toArray)
+      case x: Boolean               => BooleanValue(x)
+      case x: String                => StringValue(x)
+      case x: Double                => DoubleValue(x)
+      case x: Float                 => FloatValue(x)
+      case x: Int                   => IntValue(x)
+      case x: Long                  => LongValue(x)
     }
   }
 

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
@@ -5,9 +5,11 @@ import overflowdb.{Element, Graph}
 
 import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic.AtomicInteger
-import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsScala}
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, IteratorHasAsScala, MapHasAsScala}
 import overflowdb.formats.graphson.GraphSONProtocol._
 import spray.json._
+
+import java.util
 
 object GraphSONExporter extends Exporter {
 
@@ -74,7 +76,8 @@ object GraphSONExporter extends Exporter {
   def valueEntry(propertyValue: Any): PropertyValue = {
     // Other types require explicit type definitions to be interpreted other than string or bool
     propertyValue match {
-      case x: Seq[_]  => ListValue(x.map(valueEntry))
+      case x: Array[_]  => ListValue(x.map(valueEntry))
+      case x: util.List[_] => ListValue(x.asScala.map(valueEntry).toArray)
       case x: Boolean => BooleanValue(x)
       case x: String  => StringValue(x)
       case x: Double  => DoubleValue(x)

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
@@ -10,10 +10,10 @@ import scala.io.Source.fromFile
 import scala.util.Using
 
 /**
- * Imports OverflowDB graph to GraphSON 3.0
- *
- * https://tinkerpop.apache.org/docs/3.4.1/dev/io/#graphson-3d0
- */
+  * Imports OverflowDB graph to GraphSON 3.0
+  *
+  * https://tinkerpop.apache.org/docs/3.4.1/dev/io/#graphson-3d0
+  */
 object GraphSONImporter extends Importer {
 
   override def runImport(graph: Graph, inputFiles: Seq[Path]): Unit = {
@@ -26,21 +26,24 @@ object GraphSONImporter extends Importer {
   }
 
   private def addNode(n: Vertex, graph: Graph): Unit = {
-    graph.addNode(n.id.`@value`, n.label, unboxProperties(n.properties): _*)
+    graph.addNode(n.id.`@value`, n.label, flattenProperties(n.properties): _*)
   }
 
-  private def unboxProperties(m: Map[String, Property]): Array[_] = {
-    m.flatMap {
-      case (k, v) => v.`@value` match {
-        case x: ListValue => Seq(k, x.`@value`.map(_.`@value`))
-        case x => Seq(k, x.`@value`)
+  private def flattenProperties(m: Map[String, Property]): Array[_] = {
+    m.view
+      .mapValues { v =>
+        v.`@value` match {
+          case x: ListValue => x.`@value`.map(_.`@value`)
+          case x            => x.`@value`
+        }
       }
-    }.toArray
+      .flatMap { case (k, v) => Seq(k, v) }
+      .toArray
   }
 
   private def addEdge(e: Edge, graph: Graph): Unit = {
     val src = graph.node(e.outV.`@value`)
     val tgt = graph.node(e.inV.`@value`)
-    src.addEdge(e.label, tgt, unboxProperties(e.properties): _*)
+    src.addEdge(e.label, tgt, flattenProperties(e.properties): _*)
   }
 }

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
@@ -1,0 +1,38 @@
+package overflowdb.formats.graphson
+
+import overflowdb.Graph
+import overflowdb.formats.Importer
+import overflowdb.formats.graphson.GraphSONProtocol._
+import spray.json._
+
+import java.nio.file.Path
+import scala.io.Source.fromFile
+
+object GraphSONImporter extends Importer {
+  override def runImport(graph: Graph, inputFiles: Seq[Path]): Unit = {
+    assert(inputFiles.size == 1, s"input must be exactly one file, but got ${inputFiles.size}")
+    val source = fromFile(inputFiles.head.toFile)
+    val graphSON = try source.mkString.parseJson.convertTo[GraphSON]
+    finally source.close()
+    graphSON.`@value`.vertices.foreach(n => addNode(n, graph))
+    graphSON.`@value`.edges.foreach(e => addEdge(e, graph))
+  }
+
+  private def addNode(n: Vertex, graph: Graph): Unit = {
+    graph.addNode(n.id.`@value`, n.label, unboxVertexProperties(n.properties): _*)
+  }
+
+  private def unboxVertexProperties(m: Map[String, VertexProperty]): Array[_] = {
+    m.flatMap { case (k, v) => Seq(k, v.`@value`) }.toArray
+  }
+
+  private def unboxEdgeProperties(m: Map[String, Property]): Array[_] = {
+    m.flatMap { case (k, v) => Seq(k, v.`@value`) }.toArray
+  }
+
+  private def addEdge(e: Edge, graph: Graph): Unit = {
+    val src = graph.node(e.inV.`@value`)
+    val tgt = graph.node(e.outV.`@value`)
+    src.addEdge(e.label, tgt, unboxEdgeProperties(e.properties))
+  }
+}

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
@@ -8,7 +8,13 @@ import spray.json._
 import java.nio.file.Path
 import scala.io.Source.fromFile
 
+/**
+ * Imports OverflowDB graph to GraphSON 3.0
+ *
+ * https://tinkerpop.apache.org/docs/3.4.1/dev/io/#graphson-3d0
+ */
 object GraphSONImporter extends Importer {
+
   override def runImport(graph: Graph, inputFiles: Seq[Path]): Unit = {
     assert(inputFiles.size == 1, s"input must be exactly one file, but got ${inputFiles.size}")
     val source = fromFile(inputFiles.head.toFile)
@@ -19,19 +25,10 @@ object GraphSONImporter extends Importer {
   }
 
   private def addNode(n: Vertex, graph: Graph): Unit = {
-    graph.addNode(n.id.`@value`, n.label, unboxVertexProperties(n.properties): _*)
+    graph.addNode(n.id.`@value`, n.label, unboxProperties(n.properties): _*)
   }
 
-  private def unboxVertexProperties(m: Map[String, VertexProperty]): Array[_] = {
-    m.flatMap {
-      case (k, v) => v.`@value` match {
-        case x: ListValue => Seq(k, x.`@value`.map(_.`@value`))
-        case x => Seq(k, x.`@value`)
-      }
-    }.toArray
-  }
-
-  private def unboxEdgeProperties(m: Map[String, Property]): Array[_] = {
+  private def unboxProperties(m: Map[String, Property]): Array[_] = {
     m.flatMap {
       case (k, v) => v.`@value` match {
         case x: ListValue => Seq(k, x.`@value`.map(_.`@value`))
@@ -43,6 +40,6 @@ object GraphSONImporter extends Importer {
   private def addEdge(e: Edge, graph: Graph): Unit = {
     val src = graph.node(e.outV.`@value`)
     val tgt = graph.node(e.inV.`@value`)
-    src.addEdge(e.label, tgt, unboxEdgeProperties(e.properties): _*)
+    src.addEdge(e.label, tgt, unboxProperties(e.properties): _*)
   }
 }

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
@@ -19,7 +19,7 @@ object GraphSONImporter extends Importer {
   override def runImport(graph: Graph, inputFiles: Seq[Path]): Unit = {
     assert(inputFiles.size == 1, s"input must be exactly one file, but got ${inputFiles.size}")
     Using.resource(fromFile(inputFiles.head.toFile)) { source =>
-      val graphSON = try source.mkString.parseJson.convertTo[GraphSON]
+      val graphSON = source.mkString.parseJson.convertTo[GraphSON]
       graphSON.`@value`.vertices.foreach(n => addNode(n, graph))
       graphSON.`@value`.edges.foreach(e => addEdge(e, graph))
     }

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONImporter.scala
@@ -23,16 +23,26 @@ object GraphSONImporter extends Importer {
   }
 
   private def unboxVertexProperties(m: Map[String, VertexProperty]): Array[_] = {
-    m.flatMap { case (k, v) => Seq(k, v.`@value`) }.toArray
+    m.flatMap {
+      case (k, v) => v.`@value` match {
+        case x: ListValue => Seq(k, x.`@value`.map(_.`@value`))
+        case x => Seq(k, x.`@value`)
+      }
+    }.toArray
   }
 
   private def unboxEdgeProperties(m: Map[String, Property]): Array[_] = {
-    m.flatMap { case (k, v) => Seq(k, v.`@value`) }.toArray
+    m.flatMap {
+      case (k, v) => v.`@value` match {
+        case x: ListValue => Seq(k, x.`@value`.map(_.`@value`))
+        case x => Seq(k, x.`@value`)
+      }
+    }.toArray
   }
 
   private def addEdge(e: Edge, graph: Graph): Unit = {
-    val src = graph.node(e.inV.`@value`)
-    val tgt = graph.node(e.outV.`@value`)
-    src.addEdge(e.label, tgt, unboxEdgeProperties(e.properties))
+    val src = graph.node(e.outV.`@value`)
+    val tgt = graph.node(e.inV.`@value`)
+    src.addEdge(e.label, tgt, unboxEdgeProperties(e.properties): _*)
   }
 }

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONProtocol.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONProtocol.scala
@@ -41,16 +41,12 @@ object GraphSONProtocol extends DefaultJsonProtocol {
       value match {
         case JsString(v)  => return StringValue(v)
         case JsBoolean(v) => return BooleanValue(v)
-        case _ =>
+        case _            =>
       }
       value.asJsObject.getFields("@value", "@type") match {
-        case Seq(JsArray(v), JsString(_)) =>
-          ListValue(v.map({
-            case lx: JsValue => read(lx)
-            case _           => deserializationError("PropertyValue within list expected")
-          }).toArray)
-        case x: Seq[_] => readNonList(x)
-        case _         => deserializationError("PropertyValue expected")
+        case Seq(JsArray(v), JsString(_)) => ListValue(v.map(read).toArray)
+        case x: Seq[_]                    => readNonList(x)
+        case null                         => deserializationError("PropertyValue expected")
       }
     }
 
@@ -70,20 +66,25 @@ object GraphSONProtocol extends DefaultJsonProtocol {
 
     def read(value: JsValue): LongValue with Product =
       value.asJsObject.getFields("@value", "@type") match {
-      case Seq(JsNumber(v), JsString(typ)) if typ.equals(Type.Long.typ) =>
-        LongValue(v.toLongExact)
-      case _ => deserializationError("LongValue expected")
-    }
+        case Seq(JsNumber(v), JsString(typ)) if typ.equals(Type.Long.typ) =>
+          LongValue(v.toLongExact)
+        case _ => deserializationError("LongValue expected")
+      }
   }
 
-  implicit val propertyFormat: RootJsonFormat[Property] = jsonFormat3(Property)
+  implicit val propertyFormat: RootJsonFormat[Property] =
+    jsonFormat3(Property.apply)
 
-  implicit val vertexFormat: RootJsonFormat[Vertex] = jsonFormat4(Vertex)
+  implicit val vertexFormat: RootJsonFormat[Vertex] =
+    jsonFormat4(Vertex.apply)
 
-  implicit val edgeFormat: RootJsonFormat[Edge] = jsonFormat8(Edge)
+  implicit val edgeFormat: RootJsonFormat[Edge] =
+    jsonFormat8(Edge.apply)
 
-  implicit val graphSONElementsFormat: RootJsonFormat[GraphSONElements] = jsonFormat2(GraphSONElements)
+  implicit val graphSONElementsFormat: RootJsonFormat[GraphSONElements] =
+    jsonFormat2(GraphSONElements.apply)
 
-  implicit val graphSONFormat: RootJsonFormat[GraphSON] = jsonFormat2(GraphSON)
+  implicit val graphSONFormat: RootJsonFormat[GraphSON] =
+    jsonFormat2(GraphSON.apply)
 
 }

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONProtocol.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONProtocol.scala
@@ -8,29 +8,54 @@ object GraphSONProtocol extends DefaultJsonProtocol {
       c match {
         case x: StringValue  => JsString(x.`@value`)
         case x: BooleanValue => JsBoolean(x.`@value`)
-        case x: ListValue    => JsArray(x.`@value`.map(write).toVector)
-        case x: LongValue    => JsNumber(x.`@value`)
-        case x: IntValue     => JsNumber(x.`@value`)
-        case x: FloatValue   => JsNumber(x.`@value`)
-        case x: DoubleValue  => JsNumber(x.`@value`)
-        case _               => serializationError("PropertyValue expected")
+        case x: ListValue =>
+          JsObject(
+            "@value" -> JsArray(x.`@value`.map(write).toVector),
+            "@type" -> JsString(x.`@type`)
+          )
+        case x: LongValue =>
+          JsObject(
+            "@value" -> JsNumber(x.`@value`),
+            "@type" -> JsString(x.`@type`)
+          )
+        case x: IntValue =>
+          JsObject(
+            "@value" -> JsNumber(x.`@value`),
+            "@type" -> JsString(x.`@type`)
+          )
+        case x: FloatValue =>
+          JsObject(
+            "@value" -> JsNumber(x.`@value`),
+            "@type" -> JsString(x.`@type`)
+          )
+        case x: DoubleValue =>
+          JsObject(
+            "@value" -> JsNumber(x.`@value`),
+            "@type" -> JsString(x.`@type`)
+          )
+        case _ => serializationError("PropertyValue expected")
       }
     }
 
-    def read(value: JsValue): PropertyValue with Product = value match {
-      case JsArray(Vector(JsArray(v), JsString(_))) =>
-        ListValue(v.map({
-          case lx: JsValue => read(lx)
-          case _           => deserializationError("PropertyValue within list expected")
-        }))
-      case x: JsArray => readNonList(x)
-      case _          => deserializationError("PropertyValue expected")
+    def read(value: JsValue): PropertyValue with Product = {
+      value match {
+        case JsString(v)  => return StringValue(v)
+        case JsBoolean(v) => return BooleanValue(v)
+        case _ =>
+      }
+      value.asJsObject.getFields("@value", "@type") match {
+        case Seq(JsArray(v), JsString(_)) =>
+          ListValue(v.map({
+            case lx: JsValue => read(lx)
+            case _           => deserializationError("PropertyValue within list expected")
+          }).toArray)
+        case x: Seq[_] => readNonList(x)
+        case _         => deserializationError("PropertyValue expected")
+      }
     }
 
-    def readNonList(value: JsValue): PropertyValue with Product = value match {
-      case JsString(v)  => StringValue(v)
-      case JsBoolean(v) => BooleanValue(v)
-      case JsArray(Vector(JsNumber(v), JsString(typ))) =>
+    def readNonList(value: Seq[_]): PropertyValue with Product = value match {
+      case Seq(JsNumber(v), JsString(typ)) =>
         if (typ.equals(Type.Long.typ)) LongValue(v.toLongExact)
         else if (typ.equals(Type.Int.typ)) IntValue(v.toIntExact)
         else if (typ.equals(Type.Float.typ)) FloatValue(v.toFloat)
@@ -43,8 +68,9 @@ object GraphSONProtocol extends DefaultJsonProtocol {
   implicit object LongValueFormat extends RootJsonFormat[LongValue] {
     def write(c: LongValue): JsValue = PropertyValueJsonFormat.write(c)
 
-    def read(value: JsValue): LongValue with Product = value match {
-      case JsArray(Vector(JsNumber(v), JsString(typ))) if typ.equals(Type.Long.typ) =>
+    def read(value: JsValue): LongValue with Product =
+      value.asJsObject.getFields("@value", "@type") match {
+      case Seq(JsNumber(v), JsString(typ)) if typ.equals(Type.Long.typ) =>
         LongValue(v.toLongExact)
       case _ => deserializationError("LongValue expected")
     }

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONProtocol.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONProtocol.scala
@@ -78,8 +78,6 @@ object GraphSONProtocol extends DefaultJsonProtocol {
 
   implicit val propertyFormat: RootJsonFormat[Property] = jsonFormat3(Property)
 
-  implicit val vertexPropertyFormat: RootJsonFormat[VertexProperty] = jsonFormat3(VertexProperty)
-
   implicit val vertexFormat: RootJsonFormat[Vertex] = jsonFormat4(Vertex)
 
   implicit val edgeFormat: RootJsonFormat[Edge] = jsonFormat8(Edge)

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONProtocol.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONProtocol.scala
@@ -1,0 +1,65 @@
+package overflowdb.formats.graphson
+import spray.json._
+
+object GraphSONProtocol extends DefaultJsonProtocol {
+
+  implicit object PropertyValueJsonFormat extends RootJsonFormat[PropertyValue] {
+    def write(c: PropertyValue): JsValue = {
+      c match {
+        case x: StringValue  => JsString(x.`@value`)
+        case x: BooleanValue => JsBoolean(x.`@value`)
+        case x: ListValue    => JsArray(x.`@value`.map(write).toVector)
+        case x: LongValue    => JsNumber(x.`@value`)
+        case x: IntValue     => JsNumber(x.`@value`)
+        case x: FloatValue   => JsNumber(x.`@value`)
+        case x: DoubleValue  => JsNumber(x.`@value`)
+        case _               => serializationError("PropertyValue expected")
+      }
+    }
+
+    def read(value: JsValue): PropertyValue with Product = value match {
+      case JsArray(Vector(JsArray(v), JsString(_))) =>
+        ListValue(v.map({
+          case lx: JsValue => read(lx)
+          case _           => deserializationError("PropertyValue within list expected")
+        }))
+      case x: JsArray => readNonList(x)
+      case _          => deserializationError("PropertyValue expected")
+    }
+
+    def readNonList(value: JsValue): PropertyValue with Product = value match {
+      case JsString(v)  => StringValue(v)
+      case JsBoolean(v) => BooleanValue(v)
+      case JsArray(Vector(JsNumber(v), JsString(typ))) =>
+        if (typ.equals(Type.Long.typ)) LongValue(v.toLongExact)
+        else if (typ.equals(Type.Int.typ)) IntValue(v.toIntExact)
+        else if (typ.equals(Type.Float.typ)) FloatValue(v.toFloat)
+        else if (typ.equals(Type.Double.typ)) DoubleValue(v.toDouble)
+        else deserializationError("Valid number type or list expected")
+      case _ => deserializationError("PropertyValue expected")
+    }
+  }
+
+  implicit object LongValueFormat extends RootJsonFormat[LongValue] {
+    def write(c: LongValue): JsValue = PropertyValueJsonFormat.write(c)
+
+    def read(value: JsValue): LongValue with Product = value match {
+      case JsArray(Vector(JsNumber(v), JsString(typ))) if typ.equals(Type.Long.typ) =>
+        LongValue(v.toLongExact)
+      case _ => deserializationError("LongValue expected")
+    }
+  }
+
+  implicit val propertyFormat: RootJsonFormat[Property] = jsonFormat3(Property)
+
+  implicit val vertexPropertyFormat: RootJsonFormat[VertexProperty] = jsonFormat3(VertexProperty)
+
+  implicit val vertexFormat: RootJsonFormat[Vertex] = jsonFormat4(Vertex)
+
+  implicit val edgeFormat: RootJsonFormat[Edge] = jsonFormat8(Edge)
+
+  implicit val graphSONElementsFormat: RootJsonFormat[GraphSONElements] = jsonFormat2(GraphSONElements)
+
+  implicit val graphSONFormat: RootJsonFormat[GraphSON] = jsonFormat2(GraphSON)
+
+}

--- a/formats/src/main/scala/overflowdb/formats/graphson/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/package.scala
@@ -50,7 +50,7 @@ package object graphson {
 
   case class Vertex(id: LongValue,
                     label: String,
-                    properties: Map[String, VertexProperty],
+                    properties: Map[String, Property],
                     `@type`: String = "g:Vertex")
 
   case class Edge(id: LongValue,
@@ -90,7 +90,4 @@ package object graphson {
 
   case class Property(id: LongValue, `@value`: PropertyValue, `@type`: String = "g:Property")
 
-  case class VertexProperty(id: LongValue,
-                            `@value`: PropertyValue,
-                            `@type`: String = "g:VertexProperty")
 }

--- a/formats/src/main/scala/overflowdb/formats/graphson/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/package.scala
@@ -1,0 +1,96 @@
+package overflowdb.formats
+
+import scala.language.implicitConversions
+
+package object graphson {
+
+  object Type extends Enumeration {
+    // Boolean and String do not require type specification
+    // strings are simply in quotes and booleans are not
+    // We use the following as placeholders
+    val Boolean = Val(1, "g:Boolean")
+    val String = Val(2, "g:String")
+    val Int = Val(3, "g:Int32")
+    val Long = Val(4, "g:Int64")
+    val Float = Val(5, "g:Float")
+    val Double = Val(6, "g:Double")
+    val List = Val(7, "g:List")
+
+    def fromRuntimeClass(clazz: Class[_]): Type.Value = {
+      if (clazz.isAssignableFrom(classOf[Boolean]) || clazz.isAssignableFrom(
+            classOf[java.lang.Boolean]))
+        Type.Boolean
+      else if (clazz.isAssignableFrom(classOf[Int]) || clazz.isAssignableFrom(classOf[Integer]))
+        Type.Int
+      else if (clazz.isAssignableFrom(classOf[Long]) || clazz.isAssignableFrom(
+                 classOf[java.lang.Long]))
+        Type.Long
+      else if (clazz.isAssignableFrom(classOf[Float]) || clazz.isAssignableFrom(
+                 classOf[java.lang.Float]))
+        Type.Float
+      else if (clazz.isAssignableFrom(classOf[Double]) || clazz.isAssignableFrom(
+                 classOf[java.lang.Double]))
+        Type.Double
+      else if (clazz.isAssignableFrom(classOf[String]))
+        Type.String
+      else if (clazz.isAssignableFrom(classOf[List[_]]))
+        Type.List
+      else
+        throw new AssertionError(
+          s"unsupported runtime class `$clazz` - only ${Type.values.mkString("|")} are supported...}")
+    }
+
+    protected case class Val(num: Int, typ: String) extends super.Val
+    implicit def name(x: Val): String = x.typ
+  }
+
+  case class GraphSON(`@value`: GraphSONElements, `@type`: String = "tinker:graph")
+
+  case class GraphSONElements(vertices: Seq[Vertex], edges: Seq[Edge])
+
+  case class Vertex(id: LongValue,
+                    label: String,
+                    properties: Map[String, VertexProperty],
+                    `@type`: String = "g:Vertex")
+
+  case class Edge(id: LongValue,
+                  label: String,
+                  inVLabel: String,
+                  outVLabel: String,
+                  inV: LongValue,
+                  outV: LongValue,
+                  properties: Map[String, Property],
+                  `@type`: String = "g:Edge")
+
+  trait PropertyValue {
+    def `@value`: Any
+    def `@type`: String
+  }
+
+  case class StringValue(override val `@value`: String, `@type`: String = Type.String.typ)
+    extends PropertyValue
+
+  case class BooleanValue(override val `@value`: Boolean, `@type`: String = Type.Boolean.typ)
+    extends PropertyValue
+
+  case class LongValue(override val `@value`: Long, `@type`: String = Type.Long.typ)
+      extends PropertyValue
+
+  case class IntValue(override val `@value`: Int, `@type`: String = Type.Int.typ)
+      extends PropertyValue
+
+  case class DoubleValue(override val `@value`: Double, `@type`: String = Type.Double.typ)
+      extends PropertyValue
+
+  case class FloatValue(override val `@value`: Float, `@type`: String = Type.Float.typ)
+      extends PropertyValue
+
+  case class ListValue(override val `@value`: Seq[PropertyValue], `@type`: String = Type.List.typ)
+      extends PropertyValue
+
+  case class Property(id: LongValue, `@value`: PropertyValue, `@type`: String = "g:Property")
+
+  case class VertexProperty(id: LongValue,
+                            `@value`: PropertyValue,
+                            `@type`: String = "g:VertexProperty")
+}

--- a/formats/src/main/scala/overflowdb/formats/graphson/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/package.scala
@@ -85,7 +85,7 @@ package object graphson {
   case class FloatValue(override val `@value`: Float, `@type`: String = Type.Float.typ)
       extends PropertyValue
 
-  case class ListValue(override val `@value`: Seq[PropertyValue], `@type`: String = Type.List.typ)
+  case class ListValue(override val `@value`: Array[PropertyValue], `@type`: String = Type.List.typ)
       extends PropertyValue
 
   case class Property(id: LongValue, `@value`: PropertyValue, `@type`: String = "g:Property")

--- a/formats/src/main/scala/overflowdb/formats/graphson/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/package.scala
@@ -8,13 +8,13 @@ package object graphson {
     // Boolean and String do not require type specification
     // strings are simply in quotes and booleans are not
     // We use the following as placeholders
-    val Boolean = Val(1, "g:Boolean")
-    val String = Val(2, "g:String")
-    val Int = Val(3, "g:Int32")
-    val Long = Val(4, "g:Int64")
-    val Float = Val(5, "g:Float")
-    val Double = Val(6, "g:Double")
-    val List = Val(7, "g:List")
+    val Boolean = GraphSONVal(1, "g:Boolean")
+    val String = GraphSONVal(2, "g:String")
+    val Int = GraphSONVal(3, "g:Int32")
+    val Long = GraphSONVal(4, "g:Int64")
+    val Float = GraphSONVal(5, "g:Float")
+    val Double = GraphSONVal(6, "g:Double")
+    val List = GraphSONVal(7, "g:List")
 
     def fromRuntimeClass(clazz: Class[_]): Type.Value = {
       if (clazz.isAssignableFrom(classOf[Boolean]) || clazz.isAssignableFrom(
@@ -40,8 +40,8 @@ package object graphson {
           s"unsupported runtime class `$clazz` - only ${Type.values.mkString("|")} are supported...}")
     }
 
-    protected case class Val(num: Int, typ: String) extends super.Val
-    implicit def name(x: Val): String = x.typ
+    protected case class GraphSONVal(num: Int, typ: String) extends super.Val
+    implicit def name(x: GraphSONVal): String = x.typ
   }
 
   case class GraphSON(`@value`: GraphSONElements, `@type`: String = "tinker:graph")

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -7,7 +7,7 @@ import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
 
 package object formats {
   object Format extends Enumeration {
-    val Neo4jCsv, GraphMl, Dot = Value
+    val Neo4jCsv, GraphMl, GraphSon, Dot = Value
 
     lazy val byNameLowercase: Map[String, Format.Value] =
       values.map(format => (format.toString.toLowerCase, format)).toMap

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -7,7 +7,7 @@ import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
 
 package object formats {
   object Format extends Enumeration {
-    val Neo4jCsv, GraphMl, GraphSon, Dot = Value
+    val Neo4jCsv, GraphML, GraphSON, Dot = Value
 
     lazy val byNameLowercase: Map[String, Format.Value] =
       values.map(format => (format.toString.toLowerCase, format)).toMap

--- a/formats/src/test/resources/graphson-small.json
+++ b/formats/src/test/resources/graphson-small.json
@@ -1,0 +1,106 @@
+{
+  "@type": "tinker:graph",
+  "@value": {
+    "edges": [{
+      "@type": "g:Edge",
+      "id": {
+        "@type": "g:Int64",
+        "@value": 0
+      },
+      "inV": {
+        "@type": "g:Int64",
+        "@value": 340
+      },
+      "inVLabel": "artist",
+      "label": "sungBy",
+      "outV": {
+        "@type": "g:Int64",
+        "@value": 1
+      },
+      "outVLabel": "song",
+      "properties": {
+
+      }
+    }, {
+      "@type": "g:Edge",
+      "id": {
+        "@type": "g:Int64",
+        "@value": 1
+      },
+      "inV": {
+        "@type": "g:Int64",
+        "@value": 527
+      },
+      "inVLabel": "artist",
+      "label": "writtenBy",
+      "outV": {
+        "@type": "g:Int64",
+        "@value": 1
+      },
+      "outVLabel": "song",
+      "properties": {
+
+      }
+    }],
+    "vertices": [{
+      "@type": "g:Vertex",
+      "id": {
+        "@type": "g:Int64",
+        "@value": 1
+      },
+      "label": "song",
+      "properties": {
+        "name": {
+          "@type": "g:VertexProperty",
+          "@value": "HEY BO DIDDLEY",
+          "id": {
+            "@type": "g:Int64",
+            "@value": 0
+          }
+        },
+        "songType": {
+          "@type": "g:VertexProperty",
+          "@value": "cover",
+          "id": {
+            "@type": "g:Int64",
+            "@value": 1
+          }
+        }
+      }
+    }, {
+      "@type": "g:Vertex",
+      "id": {
+        "@type": "g:Int64",
+        "@value": 340
+      },
+      "label": "artist",
+      "properties": {
+        "name": {
+          "@type": "g:VertexProperty",
+          "@value": "Garcia",
+          "id": {
+            "@type": "g:Int64",
+            "@value": 2
+          }
+        }
+      }
+    }, {
+      "@type": "g:Vertex",
+      "id": {
+        "@type": "g:Int64",
+        "@value": 527
+      },
+      "label": "artist",
+      "properties": {
+        "name": {
+          "@type": "g:VertexProperty",
+          "@value": "Bo_Diddley",
+          "id": {
+            "@type": "g:Int64",
+            "@value": 3
+          }
+        }
+      }
+    }]
+  }
+}

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -17,7 +17,7 @@ class GraphMLTests extends AnyWordSpec {
     val graph = GratefulDead.newGraph()
     graph.nodeCount() shouldBe 0
 
-    GraphMLImporter.runImport(graph, Paths.get(getClass.getResource("graphml-small.xml").toURI))
+    GraphMLImporter.runImport(graph, Paths.get(getClass.getResource("/graphml-small.xml").toURI))
     graph.nodeCount() shouldBe 3
     graph.edgeCount() shouldBe 2
 

--- a/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphml/GraphMLTests.scala
@@ -17,7 +17,7 @@ class GraphMLTests extends AnyWordSpec {
     val graph = GratefulDead.newGraph()
     graph.nodeCount() shouldBe 0
 
-    GraphMLImporter.runImport(graph, Paths.get("src/test/resources/graphml-small.xml"))
+    GraphMLImporter.runImport(graph, Paths.get(getClass.getResource("graphml-small.xml").toURI))
     graph.nodeCount() shouldBe 3
     graph.edgeCount() shouldBe 2
 
@@ -110,6 +110,5 @@ class GraphMLTests extends AnyWordSpec {
       }
     }
   }
-
 
 }

--- a/formats/src/test/scala/overflowdb/formats/graphson/GraphSONTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphson/GraphSONTests.scala
@@ -83,7 +83,7 @@ class GraphSONTests extends AnyWordSpec {
     "using list properties" in {
       val graph = SimpleDomain.newGraph()
 
-      // will not discard the list properties
+      // should not discard the list properties
       graph.addNode(
         1,
         TestNode.LABEL,

--- a/formats/src/test/scala/overflowdb/formats/graphson/GraphSONTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphson/GraphSONTests.scala
@@ -110,9 +110,7 @@ class GraphSONTests extends AnyWordSpec {
         val diff = DiffTool.compare(graph, reimported)
         val diffString = diff.asScala.mkString(lineSeparator)
         withClue(
-          "despite the original graph containing two list properties, these are preserved in GraphSON" +
-            diffString +
-            lineSeparator) {
+          s"original graph contained two list properties, these should also be present in reimported graph $diffString $lineSeparator") {
           diff.size shouldBe 0
         }
       }

--- a/formats/src/test/scala/overflowdb/formats/graphson/GraphSONTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphson/GraphSONTests.scala
@@ -1,0 +1,122 @@
+package overflowdb.formats.graphson
+
+import better.files.File
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+import overflowdb.testdomains.gratefuldead.GratefulDead
+import overflowdb.testdomains.simple.{FunkyList, SimpleDomain, TestEdge, TestNode}
+import overflowdb.util.DiffTool
+
+import java.lang.System.lineSeparator
+import java.nio.file.Paths
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, IterableHasAsJava}
+
+class GraphSONTests extends AnyWordSpec {
+
+  "import minified gratefuldead graph" in {
+    val graph = GratefulDead.newGraph()
+    graph.nodeCount() shouldBe 0
+
+    GraphSONImporter.runImport(graph, Paths.get(getClass.getResource("/graphson-small.json").toURI))
+    graph.nodeCount() shouldBe 3
+    graph.edgeCount() shouldBe 2
+
+    val node1 = graph.node(1)
+    node1.label() shouldBe "song"
+    val node340 = node1.out("sungBy").next()
+    val node527 = node1.out("writtenBy").next()
+
+    node340.label shouldBe "artist"
+    node340.property("name") shouldBe "Garcia"
+    node340.out().hasNext shouldBe false
+    node340.in().hasNext shouldBe true
+
+    node527.label shouldBe "artist"
+    node527.property("name") shouldBe "Bo_Diddley"
+    node527.out().hasNext shouldBe false
+    node527.in().hasNext shouldBe true
+
+    graph.close()
+  }
+
+  "Exporter should export valid json" when {
+    "not using (unsupported) list properties" in {
+      val graph = SimpleDomain.newGraph()
+
+      val node2 = graph.addNode(2, TestNode.LABEL, TestNode.STRING_PROPERTY, "stringProp2")
+      val node3 = graph.addNode(3, TestNode.LABEL, TestNode.INT_PROPERTY, 13)
+
+      // only allows values defined in FunkyList.funkyWords
+      val funkyList = new FunkyList()
+      funkyList.add("apoplectic")
+      funkyList.add("bucolic")
+      val node1 = graph.addNode(1,
+                                TestNode.LABEL,
+                                TestNode.INT_PROPERTY,
+                                11,
+                                TestNode.STRING_PROPERTY,
+                                "<stringProp1>",
+      )
+
+      node1.addEdge(TestEdge.LABEL, node2, TestEdge.LONG_PROPERTY, Long.MaxValue)
+      node2.addEdge(TestEdge.LABEL, node3)
+
+      File.usingTemporaryDirectory(getClass.getName) { exportRootDirectory =>
+        val exportResult = GraphSONExporter.runExport(graph, exportRootDirectory.pathAsString)
+        exportResult.nodeCount shouldBe 3
+        exportResult.edgeCount shouldBe 2
+        val Seq(graphMLFile) = exportResult.files
+
+        // import graphml into new graph, use difftool for round trip of conversion
+        val reimported = SimpleDomain.newGraph()
+        GraphSONImporter.runImport(reimported, graphMLFile)
+        val diff = DiffTool.compare(graph, reimported)
+        withClue(
+          s"original graph and reimport from graphml should be completely equal, but there are differences:\n" +
+            diff.asScala.mkString("\n") +
+            "\n") {
+          diff.size shouldBe 0
+        }
+      }
+    }
+
+    "using list properties" in {
+      val graph = SimpleDomain.newGraph()
+
+      // will not discard the list properties
+      graph.addNode(
+        1,
+        TestNode.LABEL,
+        TestNode.INT_PROPERTY,
+        11,
+        TestNode.STRING_PROPERTY,
+        "<stringProp1>",
+        TestNode.STRING_LIST_PROPERTY,
+        List("stringListProp1a", "stringListProp1b").asJava,
+        TestNode.INT_LIST_PROPERTY,
+        List(21, 31, 41).asJava,
+      )
+
+      File.usingTemporaryDirectory(getClass.getName) { exportRootDirectory =>
+        val exportResult = GraphSONExporter.runExport(graph, exportRootDirectory.pathAsString)
+        exportResult.nodeCount shouldBe 1
+        exportResult.edgeCount shouldBe 0
+        exportResult.additionalInfo.isEmpty shouldBe true
+        val Seq(graphJsonFile) = exportResult.files
+
+        // import graphml into new graph, use difftool for round trip of conversion
+        val reimported = SimpleDomain.newGraph()
+        GraphSONImporter.runImport(reimported, graphJsonFile)
+        val diff = DiffTool.compare(graph, reimported)
+        val diffString = diff.asScala.mkString(lineSeparator)
+        withClue(
+          "despite the original graph containing two list properties, these are preserved in GraphSON" +
+            diffString +
+            lineSeparator) {
+          diff.size shouldBe 0
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Following the [GraphSON 3.0 specification](https://tinkerpop.apache.org/docs/3.4.1/dev/io/#graphson-3d0) I have used [Spray JSON](https://github.com/spray/spray-json) as the JSON parsing library to add OverflowDB to/from GraphSON 3.0 support. Spray JSON was chosen as it is the same library used in `solidity2cpg` when parsing `solidity-parser` output and is implemented with case classes better type safety and not having to worry about the nitty gritty of handling raw JSON.

Resolves #325 