### PR TITLE
Graph export: allow to export subgraphs

### DIFF
--- a/formats/src/main/scala/overflowdb/formats/Exporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/Exporter.scala
@@ -1,11 +1,16 @@
 package overflowdb.formats
 
-import overflowdb.Graph
-
 import java.nio.file.{Path, Paths}
+import overflowdb.{Edge, Graph, Node}
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+
 
 trait Exporter {
-  def runExport(graph: Graph, outputFile: Path): ExportResult
+
+  def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputFile: Path): ExportResult
+
+  def runExport(graph: Graph, outputFile: Path): ExportResult =
+    runExport(graph.nodes().asScala, graph.edges().asScala, outputFile)
 
   def runExport(graph: Graph, outputFile: String): ExportResult =
     runExport(graph, Paths.get(outputFile))

--- a/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
@@ -1,10 +1,10 @@
 package overflowdb.formats.dot
 
 import overflowdb.formats.{ExportResult, Exporter, iterableForList}
-import overflowdb.{Edge, Graph, Node}
+import overflowdb.{Edge, Node}
 
 import java.nio.file.{Files, Path}
-import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
+import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.util.Using
 
 /**
@@ -20,7 +20,7 @@ import scala.util.Using
  * */
 object DotExporter extends Exporter {
 
-  override def runExport(graph: Graph, outputRootDirectory: Path) = {
+  override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputRootDirectory: Path) = {
     val outFile = resolveOutputFile(outputRootDirectory)
     var nodeCount, edgeCount = 0
 
@@ -32,12 +32,12 @@ object DotExporter extends Exporter {
 
       writeLine("digraph {")
 
-      graph.nodes().forEachRemaining { node =>
+      nodes.iterator.foreach { node =>
         nodeCount += 1
         writeLine(node2Dot(node))
       }
 
-      graph.edges().forEachRemaining { edge =>
+      edges.iterator.foreach { edge =>
         edgeCount += 1
         writeLine(edge2Dot(edge))
       }

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -1,13 +1,13 @@
 package overflowdb.formats.graphml
 
 import overflowdb.formats.{ExportResult, Exporter, isList, writeFile}
-import overflowdb.{Element, Graph}
+import overflowdb.{Edge, Element, Node}
 
 import java.lang.System.lineSeparator
 import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsScala}
+import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.xml.{PrettyPrinter, XML}
 
 /**
@@ -22,13 +22,13 @@ import scala.xml.{PrettyPrinter, XML}
  * */
 object GraphMLExporter extends Exporter {
 
-  override def runExport(graph: Graph, outputRootDirectory: Path) = {
+  override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputRootDirectory: Path) = {
     val outFile = resolveOutputFile(outputRootDirectory)
     val nodePropertyContextById = mutable.Map.empty[String, PropertyContext]
     val edgePropertyContextById = mutable.Map.empty[String, PropertyContext]
     val discardedListPropertyCount = new AtomicInteger(0)
 
-    val nodeEntries = graph.nodes().asScala.map { node =>
+    val nodeEntries = nodes.iterator.map { node =>
       s"""<node id="${node.id}">
          |    <data key="$KeyForNodeLabel">${node.label}</data>
          |    ${dataEntries("node", node, nodePropertyContextById, discardedListPropertyCount)}
@@ -36,7 +36,7 @@ object GraphMLExporter extends Exporter {
          |""".stripMargin
     }.toSeq
 
-    val edgeEntries = graph.edges().asScala.map { edge =>
+    val edgeEntries = edges.iterator.map { edge =>
       s"""<edge source="${edge.outNode.id}" target="${edge.inNode.id}">
          |    <data key="$KeyForEdgeLabel">${edge.label}</data>
          |    ${dataEntries("edge", edge, edgePropertyContextById, discardedListPropertyCount)}

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
@@ -16,8 +16,8 @@ import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
   */
 object GraphSONExporter extends Exporter {
 
-  override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[overflowdb.Edge], outputRootDirectory: Path): ExportResult = {
-    val outFile = resolveOutputFile(outputRootDirectory)
+  override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[overflowdb.Edge], outputFile: Path): ExportResult = {
+    val outFile = resolveOutputFile(outputFile)
     // OverflowDB only stores IDs on nodes. GraphSON requires IDs on properties and edges too
     // so we add them synthetically
     val propertyId = new AtomicInteger(0)
@@ -44,7 +44,7 @@ object GraphSONExporter extends Exporter {
         propertyEntry(edge, propertyId, "g:Property")
       )
     }.toSeq
-    
+
     val graphSON = GraphSON(GraphSONElements(nodeEntries, edgeEntries))
     val json = graphSON.toJson
     writeFile(outFile, json.prettyPrint)
@@ -86,14 +86,13 @@ object GraphSONExporter extends Exporter {
     }
   }
 
-  private def resolveOutputFile(outputRootDirectory: Path): Path = {
-    if (Files.exists(outputRootDirectory)) {
-      assert(Files.isDirectory(outputRootDirectory),
-             s"given output directory `$outputRootDirectory` must be a directory, but isn't...")
+  private def resolveOutputFile(outputFile: Path): Path = {
+    if (Files.exists(outputFile) && Files.isDirectory(outputFile)) {
+      outputFile.resolve("export.graphson")
     } else {
-      Files.createDirectories(outputRootDirectory)
+      Files.createDirectories(outputFile.getParent)
+      outputFile
     }
-    outputRootDirectory.resolve("export.graphson")
   }
 
 }

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -16,12 +16,6 @@ package object formats {
       byNameLowercase.values.toSeq.map(_.toString.toLowerCase).sorted
   }
 
-  private[formats] def labelsWithNodes(graph: Graph): Seq[String] = {
-    graph.nodeCountByLabel.asScala.collect {
-      case (label, count) if count > 0 => label
-    }.toSeq
-  }
-
   /**
    * @return true if the given class is either array or a (subclass of) Java Iterable or Scala IterableOnce
    */


### PR DESCRIPTION
Prerequisite for https://github.com/joernio/joern/issues/1893

Also: GraphSON export output file handling: allow to pass in file name
Previously, one could pass in a Path, but it would always create a 
directory with an `export.graphson` in it. This allows for more options to
customise the output.