### PR TITLE
exporters: consolidate logic for output files

### DIFF
--- a/formats/src/main/scala/overflowdb/formats/Exporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/Exporter.scala
@@ -7,6 +7,8 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 trait Exporter {
 
+  def defaultFileExtension: String
+
   def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputFile: Path): ExportResult
 
   def runExport(graph: Graph, outputFile: Path): ExportResult =

--- a/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
@@ -1,6 +1,6 @@
 package overflowdb.formats.dot
 
-import overflowdb.formats.{ExportResult, Exporter, iterableForList}
+import overflowdb.formats.{ExportResult, Exporter, iterableForList, resolveOutputFileSingle}
 import overflowdb.{Edge, Node}
 
 import java.nio.file.{Files, Path}
@@ -20,8 +20,8 @@ import scala.util.Using
  * */
 object DotExporter extends Exporter {
 
-  override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputRootDirectory: Path) = {
-    val outFile = resolveOutputFile(outputRootDirectory)
+  override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputFile: Path) = {
+    val outFile = resolveOutputFileSingle(outputFile, "export.dot")
     var nodeCount, edgeCount = 0
 
     Using.resource(Files.newBufferedWriter(outFile)) { writer =>
@@ -80,12 +80,4 @@ object DotExporter extends Exporter {
     }
   }
 
-  private def resolveOutputFile(outputRootDirectory: Path): Path = {
-    if (Files.exists(outputRootDirectory)) {
-      assert(Files.isDirectory(outputRootDirectory), s"given output directory `$outputRootDirectory` must be a directory, but isn't...")
-    } else {
-      Files.createDirectories(outputRootDirectory)
-    }
-    outputRootDirectory.resolve("export.dot")
-  }
 }

--- a/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/dot/DotExporter.scala
@@ -19,9 +19,10 @@ import scala.util.Using
  * https://www.slideshare.net/albazo/graphiz-using-the-dot-language
  * */
 object DotExporter extends Exporter {
+  override def defaultFileExtension = "dot"
 
   override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputFile: Path) = {
-    val outFile = resolveOutputFileSingle(outputFile, "export.dot")
+    val outFile = resolveOutputFileSingle(outputFile, s"export.$defaultFileExtension")
     var nodeCount, edgeCount = 0
 
     Using.resource(Files.newBufferedWriter(outFile)) { writer =>
@@ -79,5 +80,4 @@ object DotExporter extends Exporter {
       case value => value.toString
     }
   }
-
 }

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -22,8 +22,10 @@ import scala.xml.{PrettyPrinter, XML}
  * */
 object GraphMLExporter extends Exporter {
 
+  override def defaultFileExtension = "xml"
+
   override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputFile: Path) = {
-    val outFile = resolveOutputFileSingle(outputFile, "export.xml")
+    val outFile = resolveOutputFileSingle(outputFile, s"export.$defaultFileExtension")
     val nodePropertyContextById = mutable.Map.empty[String, PropertyContext]
     val edgePropertyContextById = mutable.Map.empty[String, PropertyContext]
     val discardedListPropertyCount = new AtomicInteger(0)

--- a/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphml/GraphMLExporter.scala
@@ -1,10 +1,10 @@
 package overflowdb.formats.graphml
 
-import overflowdb.formats.{ExportResult, Exporter, isList, writeFile}
+import overflowdb.formats.{ExportResult, Exporter, isList, resolveOutputFileSingle, writeFile}
 import overflowdb.{Edge, Element, Node}
 
 import java.lang.System.lineSeparator
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.MapHasAsScala
@@ -22,8 +22,8 @@ import scala.xml.{PrettyPrinter, XML}
  * */
 object GraphMLExporter extends Exporter {
 
-  override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputRootDirectory: Path) = {
-    val outFile = resolveOutputFile(outputRootDirectory)
+  override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[Edge], outputFile: Path) = {
+    val outFile = resolveOutputFileSingle(outputFile, "export.xml")
     val nodePropertyContextById = mutable.Map.empty[String, PropertyContext]
     val edgePropertyContextById = mutable.Map.empty[String, PropertyContext]
     val discardedListPropertyCount = new AtomicInteger(0)
@@ -83,15 +83,6 @@ object GraphMLExporter extends Exporter {
       files = Seq(outFile),
       additionalInfo
     )
-  }
-
-  private def resolveOutputFile(outputRootDirectory: Path): Path = {
-    if (Files.exists(outputRootDirectory)) {
-      assert(Files.isDirectory(outputRootDirectory), s"given output directory `$outputRootDirectory` must be a directory, but isn't...")
-    } else {
-      Files.createDirectories(outputRootDirectory)
-    }
-    outputRootDirectory.resolve("export.graphml")
   }
 
   /**

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
@@ -5,7 +5,7 @@ import overflowdb.formats.graphson.GraphSONProtocol._
 import overflowdb.{Element, Node}
 import spray.json._
 
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
 import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
 
@@ -17,7 +17,7 @@ import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
 object GraphSONExporter extends Exporter {
 
   override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[overflowdb.Edge], outputFile: Path): ExportResult = {
-    val outFile = resolveOutputFile(outputFile)
+    val outFile = resolveOutputFileSingle(outputFile, "export.json")
     // OverflowDB only stores IDs on nodes. GraphSON requires IDs on properties and edges too
     // so we add them synthetically
     val propertyId = new AtomicInteger(0)
@@ -83,15 +83,6 @@ object GraphSONExporter extends Exporter {
       case x: Float                 => FloatValue(x)
       case x: Int                   => IntValue(x)
       case x: Long                  => LongValue(x)
-    }
-  }
-
-  private def resolveOutputFile(outputFile: Path): Path = {
-    if (Files.exists(outputFile) && Files.isDirectory(outputFile)) {
-      outputFile.resolve("export.graphson")
-    } else {
-      Files.createDirectories(outputFile.getParent)
-      outputFile
     }
   }
 

--- a/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/graphson/GraphSONExporter.scala
@@ -16,8 +16,10 @@ import scala.jdk.CollectionConverters.{IterableHasAsScala, MapHasAsScala}
   */
 object GraphSONExporter extends Exporter {
 
+  override def defaultFileExtension = "json"
+
   override def runExport(nodes: IterableOnce[Node], edges: IterableOnce[overflowdb.Edge], outputFile: Path): ExportResult = {
-    val outFile = resolveOutputFileSingle(outputFile, "export.json")
+    val outFile = resolveOutputFileSingle(outputFile, s"export.$defaultFileExtension")
     // OverflowDB only stores IDs on nodes. GraphSON requires IDs on properties and edges too
     // so we add them synthetically
     val propertyId = new AtomicInteger(0)

--- a/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
+++ b/formats/src/main/scala/overflowdb/formats/neo4jcsv/Neo4jCsvExporter.scala
@@ -12,6 +12,8 @@ import scala.util.Using
 
 object Neo4jCsvExporter extends Exporter {
 
+  override def defaultFileExtension = "csv"
+
   /**
    * Exports OverflowDB Graph to neo4j csv files
    * see https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin/neo4j-admin-import/

--- a/formats/src/main/scala/overflowdb/formats/package.scala
+++ b/formats/src/main/scala/overflowdb/formats/package.scala
@@ -32,6 +32,18 @@ package object formats {
     case arr: Array[_]             => ArraySeq.unsafeWrapArray(arr)
   }
 
+  /** If given outputFile is a directory: export into a new file in that directory
+   * Otherwise: use the given outputFile as is, and create all parent directories (if not there already)
+   */
+  def resolveOutputFileSingle(outputFile: Path, defaultName: String): Path = {
+    if (Files.exists(outputFile) && Files.isDirectory(outputFile)) {
+      outputFile.resolve(defaultName)
+    } else {
+      Files.createDirectories(outputFile.getParent)
+      outputFile
+    }
+  }
+
   def writeFile(file: Path, content: String): Unit =
     Files.write(file, content.getBytes(Charset.forName("UTF-8")))
 }

--- a/formats/src/test/scala/overflowdb/formats/graphson/GraphSONTests.scala
+++ b/formats/src/test/scala/overflowdb/formats/graphson/GraphSONTests.scala
@@ -66,6 +66,7 @@ class GraphSONTests extends AnyWordSpec {
         exportResult.nodeCount shouldBe 3
         exportResult.edgeCount shouldBe 2
         val Seq(graphMLFile) = exportResult.files
+        println(graphMLFile)
 
         // import graphml into new graph, use difftool for round trip of conversion
         val reimported = SimpleDomain.newGraph()


### PR DESCRIPTION
for all 'single-outputfile-exporters':
  if the given outputFile is a directory: export into a new file in that directory
  otherwise: use the given outputFile as is, and create all parent directories (if not there already)

also: make each exporter define it's default file extension
... so that we can use exporters generically from the outside, while using
their specific correct file extensions for the resulting files