### PR TITLE
upgrade to scala 3.2.1 and adaptations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "overflowdb"
 ThisBuild/organization := "io.shiftleft"
 ThisBuild/scalaVersion := "2.13.8"
-ThisBuild/crossScalaVersions := Seq("2.13.8", "3.1.3")
+ThisBuild/crossScalaVersions := Seq("2.13.8", "3.2.1")
 publish/skip := true
 
 lazy val core        = project.in(file("core"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/traversal/src/main/scala/overflowdb/traversal/Implicits.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Implicits.scala
@@ -1,0 +1,37 @@
+package overflowdb.traversal
+
+import overflowdb.{Edge, Element, Node}
+import scala.jdk.CollectionConverters._
+
+trait Implicits {
+  implicit def jIteratortoTraversal[A](jiterator: java.util.Iterator[A]): Traversal[A] =
+    iteratorToTraversal(jiterator.asScala)
+
+  implicit def iteratorToTraversal[A](iterator: Iterator[A]): Traversal[A] =
+    iterator.to(Traversal)
+
+  implicit def iterableToTraversal[A](iterable: IterableOnce[A]): Traversal[A] =
+    Traversal.from(iterable)
+
+  implicit def toNodeTraversal[A <: Node](traversal: Traversal[A]): NodeTraversal[A] =
+    new NodeTraversal[A](traversal)
+
+  implicit def toEdgeTraversal[A <: Edge](traversal: Traversal[A]): EdgeTraversal[A] =
+    new EdgeTraversal[A](traversal)
+
+  implicit def toElementTraversal[A <: Element](traversal: Traversal[A]): ElementTraversal[A] =
+    new ElementTraversal[A](traversal)
+
+  implicit def toNodeTraversalViaAdditionalImplicit[A <: Node, Trav](traversable: Trav)(implicit toTraversal: Trav => Traversal[A]): NodeTraversal[A] =
+    new NodeTraversal[A](toTraversal(traversable))
+
+  implicit def toEdgeTraversalViaAdditionalImplicit[A <: Edge, Trav](traversable: Trav)(implicit toTraversal: Trav => Traversal[A]): EdgeTraversal[A] =
+    new EdgeTraversal[A](toTraversal(traversable))
+
+  implicit def toElementTraversalViaAdditionalImplicit[A <: Element, Trav](traversable: Trav)(implicit toTraversal: Trav => Traversal[A]): ElementTraversal[A] =
+    new ElementTraversal[A](toTraversal(traversable))
+
+  implicit def toNumericTraversal[A : Numeric](traversal: Traversal[A]): NumericTraversal[A] =
+    new NumericTraversal[A](traversal)
+
+}

--- a/traversal/src/main/scala/overflowdb/traversal/package.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/package.scala
@@ -2,40 +2,7 @@ package overflowdb
 
 import overflowdb.util.JIteratorCastingWrapper
 
-import scala.collection.IterableOnce
-import scala.jdk.CollectionConverters._
-
-package object traversal {
-
-  implicit def jIteratortoTraversal[A](jiterator: java.util.Iterator[A]): Traversal[A] =
-    iteratorToTraversal(jiterator.asScala)
-
-  implicit def iteratorToTraversal[A](iterator: Iterator[A]): Traversal[A] =
-    iterator.to(Traversal)
-
-  implicit def iterableToTraversal[A](iterable: IterableOnce[A]): Traversal[A] =
-    Traversal.from(iterable)
-
-  implicit def toNodeTraversal[A <: Node](traversal: Traversal[A]): NodeTraversal[A] =
-    new NodeTraversal[A](traversal)
-
-  implicit def toEdgeTraversal[A <: Edge](traversal: Traversal[A]): EdgeTraversal[A] =
-    new EdgeTraversal[A](traversal)
-
-  implicit def toElementTraversal[A <: Element](traversal: Traversal[A]): ElementTraversal[A] =
-    new ElementTraversal[A](traversal)
-
-  implicit def toNodeTraversalViaAdditionalImplicit[A <: Node, Trav](traversable: Trav)(implicit toTraversal: Trav => Traversal[A]): NodeTraversal[A] =
-    new NodeTraversal[A](toTraversal(traversable))
-
-  implicit def toEdgeTraversalViaAdditionalImplicit[A <: Edge, Trav](traversable: Trav)(implicit toTraversal: Trav => Traversal[A]): EdgeTraversal[A] =
-    new EdgeTraversal[A](toTraversal(traversable))
-
-  implicit def toElementTraversalViaAdditionalImplicit[A <: Element, Trav](traversable: Trav)(implicit toTraversal: Trav => Traversal[A]): ElementTraversal[A] =
-    new ElementTraversal[A](toTraversal(traversable))
-
-  implicit def toNumericTraversal[A : Numeric](traversal: Traversal[A]): NumericTraversal[A] =
-    new NumericTraversal[A](traversal)
+package object traversal extends Implicits {
 
   implicit class NodeOps[N <: Node](val node: N) extends AnyVal {
     /** start a new Traversal with this Node, i.e. lift it into a Traversal */


### PR DESCRIPTION
implicit scope resolution was changes in scala3, hence extracting implicits for later reuse
https://docs.scala-lang.org/scala3/reference/changed-features/implicit-resolution.html