### PR TITLE
fixup scalac cross build options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,12 +18,10 @@ ThisBuild/libraryDependencies ++= Seq(
 
 ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature") ++ (
   CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((3, _)) => Seq(
-          "-Xtarget:8"
-          )
-    case _ => Seq(
-          "-target:jvm-1.8"
-      )
+    case Some((3, _)) =>
+      Seq("-Xtarget:8")
+    case _ =>
+      Seq("-target:jvm-1.8", "--release", "8")
   }
 )
 
@@ -31,7 +29,6 @@ ThisBuild / compile / javacOptions ++= Seq(
   "-g", //debug symbols
   "--release=8"
 )
-ThisBuild / scalacOptions ++= Seq("-target:jvm-1.8", "--release", "8")
 
 ThisBuild/Test/testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v")
 ThisBuild/Test/fork := true
@@ -41,7 +38,6 @@ ThisBuild/resolvers ++= Seq(
   "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public")
 
 ThisBuild/Compile/scalacOptions ++= Seq(
-  "-Xfatal-warnings",
   "-language:implicitConversions",
   // "-language:existentials",
 )

--- a/formats/build.sbt
+++ b/formats/build.sbt
@@ -7,6 +7,5 @@ libraryDependencies ++= Seq(
   "com.github.scopt" %% "scopt" % "4.1.0",
   "io.spray" %% "spray-json" % "1.3.6"
 )
-scalacOptions ++= Seq("-deprecation:false")
 
 Test/console/scalacOptions -= "-Xlint"

--- a/traversal-tests/build.sbt
+++ b/traversal-tests/build.sbt
@@ -2,6 +2,4 @@ name := "overflowdb-traversal-tests"
 
 publish/skip := true
 
-scalacOptions ++= Seq("-deprecation:false")
-
 Test/console/scalacOptions -= "-Xlint"

--- a/traversal/build.sbt
+++ b/traversal/build.sbt
@@ -4,4 +4,3 @@ libraryDependencies ++= Seq(
   "net.oneandone.reflections8" % "reflections8" % "0.11.7", // go back to reflections once 0.9.13 is released
   "com.massisframework" % "j-text-utils" % "0.3.4",
 )
-scalacOptions ++= Seq("-deprecation:false")


### PR DESCRIPTION
* drop -Xfatal-warnings - was removed in most subprojects anyway
* fix `[warn] Flag -deprecation set repeatedly`
* fix `[warn] The value of -Xunchecked-java-output-version was overridden by -java-output-version`
* fix `[warn] bad option '-target:jvm-1.8' was ignored`