### PR TITLE
PathFinder: find paths between two nodes

### DIFF
--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -27,7 +27,7 @@ class PathFinderTests extends AnyWordSpec {
         center, r1
       ))
     )
-    path.withEdges shouldBe
+    path.head.withEdges shouldBe "foo"
   }
 
 }

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -6,12 +6,10 @@ import overflowdb.Direction._
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
-class PathFinderTests extends AnyWordSpec {
-  import ExampleGraphSetup._
+class PathFinderTests extends AnyWordSpec with ExampleGraphSetup {
   /* most tests work with this simple graph:
    * L3 <- L2 <- L1 <- Center -> R1 -> R2 -> R3 -> R4 -> R5
    */
-
   "identity" in {
     PathFinder(center, center) shouldBe Seq(
       Path(Seq(
@@ -27,7 +25,6 @@ class PathFinderTests extends AnyWordSpec {
         center, r1
       ))
     )
-    path.head.withEdges shouldBe "TODO"
   }
 
 }

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -1,0 +1,31 @@
+package overflowdb.algorithm
+
+import overflowdb.traversal.testdomains.simple.{Connection, ExampleGraphSetup}
+import PathFinder._
+import overflowdb.Direction._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+class PathFinderTests extends AnyWordSpec {
+  import ExampleGraphSetup._
+  /* most tests work with this simple graph:
+   * L3 <- L2 <- L1 <- Center -> R1 -> R2 -> R3 -> R4 -> R5
+   */
+
+  "identity" in {
+    PathFinder(center, center) shouldBe Seq(
+      Path(Seq(
+        NodeEntry(center)
+      ))
+    )
+  }
+
+  "direct neighbors" in {
+    PathFinder(center, r1) shouldBe Seq(
+      Path(Seq(
+        NodeEntry(center), EdgeEntry(OUT, Connection.Label), NodeEntry(r1)
+      ))
+    )
+  }
+
+}

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -15,17 +15,19 @@ class PathFinderTests extends AnyWordSpec {
   "identity" in {
     PathFinder(center, center) shouldBe Seq(
       Path(Seq(
-        NodeEntry(center)
+        center
       ))
     )
   }
 
   "direct neighbors" in {
-    PathFinder(center, r1) shouldBe Seq(
+    val path = PathFinder(center, r1)
+    path shouldBe Seq(
       Path(Seq(
-        NodeEntry(center), EdgeEntry(OUT, Connection.Label), NodeEntry(r1)
+        center, r1
       ))
     )
+    path.withEdges shouldBe
   }
 
 }

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -85,12 +85,12 @@ class PathFinderTests extends AnyWordSpec with ExampleGraphSetup {
 
   "max depth" in {
     PathFinder(center, r3, maxDepth = 3) shouldBe Seq(
-      Path(Seq(
+      Path(Vector(
         center, r1, r2, r3
       ))
     )
 
-//    PathFinder(center, r3, maxDepth = 2) shouldBe Nil
+    PathFinder(center, r3, maxDepth = 2) shouldBe Nil
   }
 
 }

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -4,8 +4,7 @@ import overflowdb.traversal.testdomains.simple.{Connection, ExampleGraphSetup}
 import PathFinder._
 import overflowdb.Direction._
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import overflowdb.Direction
+import org.scalatest.matchers.should.Matchers._
 
 class PathFinderTests extends AnyWordSpec with ExampleGraphSetup {
   /* sample graph:
@@ -33,7 +32,7 @@ class PathFinderTests extends AnyWordSpec with ExampleGraphSetup {
     )
 
     path.head.withEdges shouldBe PathWithEdges(Seq(
-      NodeEntry(center), EdgeEntry(Direction.OUT, Connection.Label), NodeEntry(r1)
+      NodeEntry(center), EdgeEntry(OUT, Connection.Label), NodeEntry(r1)
     ))
   }
 

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -8,15 +8,20 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import overflowdb.Direction
 
 class PathFinderTests extends AnyWordSpec with ExampleGraphSetup {
-  /* most tests work with this simple graph:
+  /* sample graph:
    * L3 <- L2 <- L1 <- Center -> R1 -> R2 -> R3 -> R4 -> R5
    */
   "identity" in {
-    PathFinder(center, center) shouldBe Seq(
+    val path = PathFinder(center, center)
+    path shouldBe Seq(
       Path(Seq(
         center
       ))
     )
+
+    path.head.withEdges shouldBe PathWithEdges(Seq(
+      NodeEntry(center)
+    ))
   }
 
   "direct neighbors" in {
@@ -29,6 +34,52 @@ class PathFinderTests extends AnyWordSpec with ExampleGraphSetup {
 
     path.head.withEdges shouldBe PathWithEdges(Seq(
       NodeEntry(center), EdgeEntry(Direction.OUT, Connection.Label), NodeEntry(r1)
+    ))
+  }
+
+  "longer path" in {
+    val path = PathFinder(l1, r1)
+    path shouldBe Seq(
+      Path(Seq(
+        l1, center, r1
+      ))
+    )
+
+    path.head.withEdges shouldBe PathWithEdges(Seq(
+      NodeEntry(l1),
+      EdgeEntry(IN, Connection.Label),
+      NodeEntry(center),
+      EdgeEntry(OUT, Connection.Label),
+      NodeEntry(r1),
+    ))
+  }
+
+  "longest path" in {
+    val path = PathFinder(l3, r5)
+    path shouldBe Seq(
+      Path(Seq(
+        l3, l2, l1, center, r1, r2, r3, r4, r5
+      ))
+    )
+
+    path.head.withEdges shouldBe PathWithEdges(Seq(
+      NodeEntry(l3),
+      EdgeEntry(IN, Connection.Label),
+      NodeEntry(l2),
+      EdgeEntry(IN, Connection.Label),
+      NodeEntry(l1),
+      EdgeEntry(IN, Connection.Label),
+      NodeEntry(center),
+      EdgeEntry(OUT, Connection.Label),
+      NodeEntry(r1),
+      EdgeEntry(OUT, Connection.Label),
+      NodeEntry(r2),
+      EdgeEntry(OUT, Connection.Label),
+      NodeEntry(r3),
+      EdgeEntry(OUT, Connection.Label),
+      NodeEntry(r4),
+      EdgeEntry(OUT, Connection.Label),
+      NodeEntry(r5),
     ))
   }
 

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -5,6 +5,7 @@ import PathFinder._
 import overflowdb.Direction._
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import overflowdb.Direction
 
 class PathFinderTests extends AnyWordSpec with ExampleGraphSetup {
   /* most tests work with this simple graph:
@@ -25,6 +26,10 @@ class PathFinderTests extends AnyWordSpec with ExampleGraphSetup {
         center, r1
       ))
     )
+
+    path.head.withEdges shouldBe PathWithEdges(Seq(
+      NodeEntry(center), EdgeEntry(Direction.OUT, Connection.Label), NodeEntry(r1)
+    ))
   }
 
 }

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -83,4 +83,14 @@ class PathFinderTests extends AnyWordSpec with ExampleGraphSetup {
     ))
   }
 
+  "max depth" in {
+    PathFinder(center, r3, maxDepth = 3) shouldBe Seq(
+      Path(Seq(
+        center, r1, r2, r3
+      ))
+    )
+
+//    PathFinder(center, r3, maxDepth = 2) shouldBe Nil
+  }
+
 }

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/PathFinderTests.scala
@@ -27,7 +27,7 @@ class PathFinderTests extends AnyWordSpec {
         center, r1
       ))
     )
-    path.head.withEdges shouldBe "foo"
+    path.head.withEdges shouldBe "TODO"
   }
 
 }

--- a/traversal-tests/src/test/scala/overflowdb/traversal/RepeatTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/RepeatTraversalTests.scala
@@ -167,7 +167,7 @@ class RepeatTraversalTests extends AnyWordSpec with ExampleGraphSetup {
     }
   }
 
-  ".dedup should apply to all repeat iterations" when {
+  ".dedup should apply to all repeat iterations - e.g. to avoid cycles" when {
     "path tracking is not enabled" in {
       centerTrav.repeat(_.both)(_.maxDepth(2).dedup).toSetMutable shouldBe Set(l2, r2)
       centerTrav.repeat(_.both)(_.maxDepth(3).dedup).toSetMutable shouldBe Set(l3, r3)

--- a/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
+++ b/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
@@ -1,7 +1,7 @@
 package overflowdb.algorithm
 
-import overflowdb.traversal.{RepeatBehaviour, Traversal}
 import overflowdb.{Direction, Node}
+import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 

--- a/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
+++ b/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
@@ -3,6 +3,8 @@ package overflowdb.algorithm
 import overflowdb.traversal.Traversal
 import overflowdb.{Direction, Edge, Node}
 
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+
 object PathFinder {
   def apply(nodeA: Node, nodeB: Node): Seq[Path] = {
     if (nodeA == nodeB) Seq(Path(Seq(nodeA)))
@@ -22,14 +24,14 @@ object PathFinder {
       // TODO use for comprehension?
       PathWithEdges(
         nodes.sliding(2).flatMap { case Seq(nodeA, nodeB) =>
-          val edgesBetween0: PathEntry = edgesBetween(nodeA, nodeB) match {
+          val edgesBetweenAsPathEntry: PathEntry = edgesBetween(nodeA, nodeB) match {
             case Nil => throw new AssertionError(s"no edges between nodes $nodeA and $nodeB - this looks like a bug in PathFinder")
             case Seq(edgeEntry) => edgeEntry
             case multipleEdges => EdgeEntries(multipleEdges)
           }
           Seq(
             NodeEntry(nodeA),
-            edgesBetween0,
+            edgesBetweenAsPathEntry,
             NodeEntry (nodeB),
           )
         }.to(Seq)
@@ -38,7 +40,9 @@ object PathFinder {
   }
 
   private def edgesBetween(nodeA: Node, nodeB: Node): Seq[EdgeEntry] = {
-    ???
+    val outEdges = nodeA.outE.asScala.filter(_.inNode == nodeB).map(edge => EdgeEntry(Direction.OUT, edge.label))
+    val inEdges  = nodeA.inE.asScala.filter(_.outNode == nodeB).map(edge => EdgeEntry(Direction.IN, edge.label))
+    outEdges.to(Seq) ++ inEdges.to(Seq)
   }
 
   case class PathWithEdges(elements: Seq[PathEntry])

--- a/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
+++ b/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
@@ -4,17 +4,12 @@ import overflowdb.traversal.Traversal
 import overflowdb.{Direction, Node}
 
 object PathFinder {
-  case class Path(elements: Seq[PathEntry])
-
   def apply(nodeA: Node, nodeB: Node): Seq[Path] = {
-    if (nodeA == nodeB) Seq(Path(Seq(NodeEntry(nodeA))))
+    if (nodeA == nodeB) Seq(Path(Seq(nodeA)))
     else {
       Traversal.fromSingle(nodeA)
         .enablePathTracking
-        .repeat(_.union(
-          _.outE.inV,
-          _.inE.outV
-        ))(_.emit.times(2))
+        .repeat(_.both)(_.emit.times(2))
         .path
         .foreach(println)
 
@@ -22,6 +17,28 @@ object PathFinder {
     }
   }
 
+  case class Path(nodes: Seq[Node]) {
+    def withEdges: PathWithEdges = {
+
+      // TODO use for comprehension
+      PathWithEdges(nodes.sliding(2).flatMap { case Seq(nodeA, nodeB) =>
+        edgesBetween(nodeA, nodeB).map { edgeEntry =>
+          Seq(
+            NodeEntry(nodeA),
+            edgeEntry,
+            NodeEntry (nodeB),
+          )
+        }
+      } )
+      ???
+    }
+  }
+
+  private def edgesBetween(nodeA: Node, nodeB: Node): Seq[EdgeEntry] = {
+    ???
+  }
+
+  case class PathWithEdges(elements: Seq[PathEntry])
   sealed trait PathEntry
   case class NodeEntry(node: Node) extends PathEntry {
     def label: String = node.label()
@@ -31,4 +48,6 @@ object PathFinder {
     assert(direction == Direction.IN || direction == Direction.OUT,
       s"direction must be either IN or OUT, but was $direction")
   }
+
+
 }

--- a/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
+++ b/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
@@ -21,21 +21,16 @@ object PathFinder {
 
   case class Path(nodes: Seq[Node]) {
     def withEdges: PathWithEdges = {
-      // TODO use for comprehension?
-      PathWithEdges(
-        nodes.sliding(2).flatMap { case Seq(nodeA, nodeB) =>
-          val edgesBetweenAsPathEntry: PathEntry = edgesBetween(nodeA, nodeB) match {
-            case Nil => throw new AssertionError(s"no edges between nodes $nodeA and $nodeB - this looks like a bug in PathFinder")
-            case Seq(edgeEntry) => edgeEntry
-            case multipleEdges => EdgeEntries(multipleEdges)
-          }
-          Seq(
-            NodeEntry(nodeA),
-            edgesBetweenAsPathEntry,
-            NodeEntry (nodeB),
-          )
-        }.to(Seq)
-      )
+      val nodesWithEdges = for {
+        case Seq(nodeA, nodeB) <- nodes.sliding(2)
+        edgesBetweenAsPathEntry: PathEntry = edgesBetween(nodeA, nodeB) match {
+          case Nil => throw new AssertionError(s"no edges between nodes $nodeA and $nodeB - this looks like a bug in PathFinder")
+          case Seq(edgeEntry) => edgeEntry
+          case multipleEdges => EdgeEntries(multipleEdges)
+        }
+      } yield Seq(NodeEntry(nodeA), edgesBetweenAsPathEntry, NodeEntry (nodeB))
+
+      PathWithEdges(nodesWithEdges.flatten.to(Seq))
     }
   }
 

--- a/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
+++ b/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
@@ -1,7 +1,7 @@
 package overflowdb.algorithm
 
 import overflowdb.traversal.Traversal
-import overflowdb.{Direction, Node}
+import overflowdb.{Direction, Edge, Node}
 
 object PathFinder {
   def apply(nodeA: Node, nodeB: Node): Seq[Path] = {
@@ -19,18 +19,21 @@ object PathFinder {
 
   case class Path(nodes: Seq[Node]) {
     def withEdges: PathWithEdges = {
-
-      // TODO use for comprehension
-      PathWithEdges(nodes.sliding(2).flatMap { case Seq(nodeA, nodeB) =>
-        edgesBetween(nodeA, nodeB).map { edgeEntry =>
+      // TODO use for comprehension?
+      PathWithEdges(
+        nodes.sliding(2).flatMap { case Seq(nodeA, nodeB) =>
+          val edgesBetween0: PathEntry = edgesBetween(nodeA, nodeB) match {
+            case Nil => throw new AssertionError(s"no edges between nodes $nodeA and $nodeB - this looks like a bug in PathFinder")
+            case Seq(edgeEntry) => edgeEntry
+            case multipleEdges => EdgeEntries(multipleEdges)
+          }
           Seq(
             NodeEntry(nodeA),
-            edgeEntry,
+            edgesBetween0,
             NodeEntry (nodeB),
           )
-        }
-      } )
-      ???
+        }.to(Seq)
+      )
     }
   }
 
@@ -44,6 +47,7 @@ object PathFinder {
     def label: String = node.label()
     def id: Long = node.id()
   }
+  case class EdgeEntries(edgeEntries: Seq[EdgeEntry]) extends PathEntry
   case class EdgeEntry(direction: Direction, label: String) extends PathEntry {
     assert(direction == Direction.IN || direction == Direction.OUT,
       s"direction must be either IN or OUT, but was $direction")

--- a/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
+++ b/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
@@ -1,0 +1,34 @@
+package overflowdb.algorithm
+
+import overflowdb.traversal.Traversal
+import overflowdb.{Direction, Node}
+
+object PathFinder {
+  case class Path(elements: Seq[PathEntry])
+
+  def apply(nodeA: Node, nodeB: Node): Seq[Path] = {
+    if (nodeA == nodeB) Seq(Path(Seq(NodeEntry(nodeA))))
+    else {
+      Traversal.fromSingle(nodeA)
+        .enablePathTracking
+        .repeat(_.union(
+          _.outE.inV,
+          _.inE.outV
+        ))(_.emit.times(2))
+        .path
+        .foreach(println)
+
+      ???
+    }
+  }
+
+  sealed trait PathEntry
+  case class NodeEntry(node: Node) extends PathEntry {
+    def label: String = node.label()
+    def id: Long = node.id()
+  }
+  case class EdgeEntry(direction: Direction, label: String) extends PathEntry {
+    assert(direction == Direction.IN || direction == Direction.OUT,
+      s"direction must be either IN or OUT, but was $direction")
+  }
+}

--- a/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
+++ b/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
@@ -14,16 +14,12 @@ object PathFinder {
         .repeat(_.both) { initialBehaviour =>
           val behaviour = initialBehaviour
             .dedup // no cycles
-            .emit(_.is(nodeB)) // we only care about the paths that lead to our destination
             .until(_.is(nodeB)) // don't continue on a given path if we've reached our destination
-
-          if (maxDepth > -1)
-            behaviour.maxDepth(maxDepth)
-          else
-            behaviour
+          if (maxDepth > -1) behaviour.maxDepth(maxDepth)
+          else behaviour
         }
+        .is(nodeB) // we only care about the paths that lead to our destination
         .path
-        .dedup
         .cast[Seq[Node]]
         .map(Path.apply)
         .toSeq

--- a/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
+++ b/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
@@ -9,12 +9,26 @@ object PathFinder {
   def apply(nodeA: Node, nodeB: Node): Seq[Path] = {
     if (nodeA == nodeB) Seq(Path(Seq(nodeA)))
     else {
+      println("XXX0")
       Traversal.fromSingle(nodeA)
         .enablePathTracking
-        .repeat(_.both)(_.emit.times(2))
+//        .repeat(_.both)(_.emit(_.is(nodeB)).times(1))
+        .repeat(_.both)(_.until(_.is(nodeB)))
         .path
+        .dedup
         .foreach(println)
+      println("XXX1")
 
+//      Traversal.fromSingle(nodeA)
+//        .enablePathTracking
+//        .repeat(_.both)(_.emit(_.is(nodeB)).times(1))
+//        .path
+//        .dedup
+//        .map { path =>
+//          Path(
+//            path.map(_.asInstanceOf[Node]) // safe to cast, because we called `_.both` on repeat step
+//          )
+//        }.toSeq
       ???
     }
   }

--- a/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
+++ b/traversal/src/main/scala/overflowdb/algorithm/PathFinder.scala
@@ -1,7 +1,7 @@
 package overflowdb.algorithm
 
 import overflowdb.traversal.Traversal
-import overflowdb.{Direction, Edge, Node}
+import overflowdb.{Direction, Node}
 
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
@@ -9,27 +9,17 @@ object PathFinder {
   def apply(nodeA: Node, nodeB: Node): Seq[Path] = {
     if (nodeA == nodeB) Seq(Path(Seq(nodeA)))
     else {
-      println("XXX0")
       Traversal.fromSingle(nodeA)
         .enablePathTracking
-//        .repeat(_.both)(_.emit(_.is(nodeB)).times(1))
-        .repeat(_.both)(_.until(_.is(nodeB)))
+        .repeat(_.both)(_.dedup // no cycles
+                         .emit(_.is(nodeB)) // we only care about the paths that lead to our destination
+                         //           .times(3) // TODO make configurable
+                         .until(_.is(nodeB))) // don't continue on a given path if we've reached our destination
         .path
         .dedup
-        .foreach(println)
-      println("XXX1")
-
-//      Traversal.fromSingle(nodeA)
-//        .enablePathTracking
-//        .repeat(_.both)(_.emit(_.is(nodeB)).times(1))
-//        .path
-//        .dedup
-//        .map { path =>
-//          Path(
-//            path.map(_.asInstanceOf[Node]) // safe to cast, because we called `_.both` on repeat step
-//          )
-//        }.toSeq
-      ???
+        .cast[Seq[Node]]
+        .map(Path.apply)
+        .toSeq
     }
   }
 

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -165,7 +165,7 @@ class Traversal[+A](elements: IterableOnce[A])
    *   .union(_.out, _.in)
    * }}}
    */
-  @Doc(info = "union/sum/aggregate given traversals from the current point")
+  @Doc(info = "union/sum/aggregate/join given traversals from the current point")
   def union[B](traversals: (Traversal[A] => Traversal[B])*): Traversal[B] = {
     flatMap { (a: A) =>
       traversals.flatMap(_.apply(Traversal.fromSingle(a)))

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -68,8 +68,14 @@ class Traversal[+A](elements: IterableOnce[A])
 
   /** filters out everything that is _not_ the given value */
   @Doc(info = "filters out everything that is _not_ the given value")
-  def is[B >: A](value: B): Traversal[A] =
-    filter(_ == value)
+  def is[B >: A](value: B): Traversal[A] = {
+//    filter(_ == value)
+    filter { x =>
+      val ret = x == value
+      println(s"XXX3: $x == $value : $ret")
+      ret
+    }
+  }
 
   /** filters out all elements that are _not_ in the provided set */
   @Doc(info = "filters out all elements that are _not_ in the provided set")
@@ -312,6 +318,7 @@ class Traversal[+A](elements: IterableOnce[A])
     * {{{
     *  myTraversal.enablePathTracking.out.out.path.toList
     * }}}
+    *  TODO would be nice to preserve the types of the elements, at least if they have a common supertype
     */
   @Doc(info = "retrieve entire path that has been traversed thus far")
   def path: Traversal[Vector[Any]] =

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -68,14 +68,8 @@ class Traversal[+A](elements: IterableOnce[A])
 
   /** filters out everything that is _not_ the given value */
   @Doc(info = "filters out everything that is _not_ the given value")
-  def is[B >: A](value: B): Traversal[A] = {
-//    filter(_ == value)
-    filter { x =>
-      val ret = x == value
-      println(s"XXX3: $x == $value : $ret")
-      ret
-    }
-  }
+  def is[B >: A](value: B): Traversal[A] =
+    filter(_ == value)
 
   /** filters out all elements that are _not_ in the provided set */
   @Doc(info = "filters out all elements that are _not_ in the provided set")


### PR DESCRIPTION
* useful in many debugging scenarios
* most simplistic 'algorithm': `repeat(_.both)`
* maxDepth to limit the search
* edges added on demand (there may be multiple edges between two nodes)