### PR TITLE
also temporarily comment out `toNumericTraversal`

### DIFF
--- a/traversal-tests/src/test/scala/overflowdb/traversal/GratefulDeadTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/GratefulDeadTests.scala
@@ -4,6 +4,7 @@ import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.traversal.filter.StringPropertyFilter.InvalidRegexException
 import overflowdb.traversal.testdomains.gratefuldead._
+import overflowdb.traversal.ChainedImplicitsTemp._
 
 class GratefulDeadTests extends AnyWordSpec {
   val gratefulDead = GratefulDead.traversal(GratefulDead.newGraphWithData)

--- a/traversal/src/main/scala/overflowdb/traversal/ChainedImplicitsTemp.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/ChainedImplicitsTemp.scala
@@ -14,4 +14,6 @@ object ChainedImplicitsTemp {
   implicit def toElementTraversalViaAdditionalImplicit[A <: Element, Trav](traversable: Trav)(implicit toTraversal: Trav => Traversal[A]): ElementTraversal[A] =
     new ElementTraversal[A](toTraversal(traversable))
 
+  implicit def toNumericTraversal[A : Numeric](traversal: Traversal[A]): NumericTraversal[A] =
+    new NumericTraversal[A](traversal)
 }

--- a/traversal/src/main/scala/overflowdb/traversal/Implicits.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Implicits.scala
@@ -35,8 +35,8 @@ trait Implicits {
   // implicit def toElementTraversalViaAdditionalImplicit[A <: Element, Trav](traversable: Trav)(implicit toTraversal: Trav => Traversal[A]): ElementTraversal[A] =
   //   new ElementTraversal[A](toTraversal(traversable))
 
-  implicit def toNumericTraversal[A : Numeric](traversal: Traversal[A]): NumericTraversal[A] =
-    new NumericTraversal[A](traversal)
+  // implicit def toNumericTraversal[A : Numeric](traversal: Traversal[A]): NumericTraversal[A] =
+  //   new NumericTraversal[A](traversal)
 
 }
 


### PR DESCRIPTION
* also triggers autocompletion bug in repl
* will be fixed in 3.2.2 - see https://github.com/lampepfl/dotty/issues/16360#issuecomment-1324857836
* just like 74b874b9f61c1ccc636a59e8814802a3f95944d6