### PR TITLE
make StringInterner a regular member variable, rather than static

### DIFF
--- a/core-tests/src/test/java/overflowdb/storage/OdbStorageTest.java
+++ b/core-tests/src/test/java/overflowdb/storage/OdbStorageTest.java
@@ -8,6 +8,7 @@ import overflowdb.Config;
 import overflowdb.Graph;
 import overflowdb.testdomains.gratefuldead.GratefulDead;
 import overflowdb.testdomains.gratefuldead.Song;
+import overflowdb.util.StringInterner;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class OdbStorageTest {
+  private StringInterner stringInterner = new StringInterner();
 
   @Test
   public void persistToFileIfStorageConfigured() throws IOException {
@@ -66,7 +68,7 @@ public class OdbStorageTest {
   public void shouldErrorWhenTryingToOpenWithoutStorageFormatVersion() throws IOException {
     File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
     storageFile.deleteOnExit();
-    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile);
+    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, stringInterner);
     storage.close();
 
     // modify storage: drop storage version
@@ -76,14 +78,14 @@ public class OdbStorageTest {
     store.close();
 
     // should throw a BackwardsCompatibilityError
-    OdbStorage.createWithSpecificLocation(storageFile);
+    OdbStorage.createWithSpecificLocation(storageFile, stringInterner);
   }
 
   @Test(expected = BackwardsCompatibilityError.class)
   public void shouldErrorWhenTryingToOpenDifferentStorageFormatVersion() throws IOException {
     File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
     storageFile.deleteOnExit();
-    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile);
+    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, stringInterner);
     storage.close();
 
     // modify storage: change storage version
@@ -93,14 +95,14 @@ public class OdbStorageTest {
     store.close();
 
     // should throw a BackwardsCompatibilityError
-    OdbStorage.createWithSpecificLocation(storageFile);
+    OdbStorage.createWithSpecificLocation(storageFile, stringInterner);
   }
 
   @Test
   public void shouldProvideStringToIntGlossary() throws IOException {
     File storageFile = Files.createTempFile("overflowdb", "bin").toFile();
     storageFile.deleteOnExit();
-    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile);
+    OdbStorage storage = OdbStorage.createWithSpecificLocation(storageFile, stringInterner);
 
     String a = "a";
     String b = "b";
@@ -117,7 +119,7 @@ public class OdbStorageTest {
 
     // should survive restarts
     storage.close();
-    storage = OdbStorage.createWithSpecificLocation(storageFile);
+    storage = OdbStorage.createWithSpecificLocation(storageFile, stringInterner);
     assertEquals(stringIdA, storage.lookupOrCreateStringToIntMapping(a));
     assertEquals(stringIdB, storage.lookupOrCreateStringToIntMapping(b));
 

--- a/core/src/main/java/overflowdb/storage/NodeDeserializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeDeserializer.java
@@ -23,10 +23,12 @@ public class NodeDeserializer extends BookKeeper {
   protected final Graph graph;
   private final Map<String, NodeFactory> nodeFactoryByLabel;
   private final OdbStorage storage;
+  private final StringInterner stringInterner;
 
   public NodeDeserializer(Graph graph, Map<String, NodeFactory> nodeFactoryByLabel, boolean statsEnabled, OdbStorage storage) {
     super(statsEnabled);
     this.graph = graph;
+    this.stringInterner = graph.getStringInterner();
     this.nodeFactoryByLabel = nodeFactoryByLabel;
     this.storage = storage;
   }
@@ -111,7 +113,7 @@ public class NodeDeserializer extends BookKeeper {
       case BOOLEAN:
         return value.asBooleanValue().getBoolean();
       case STRING:
-        return StringInterner.intern(value.asStringValue().asString());
+        return stringInterner.intern(value.asStringValue().asString());
       case BYTE:
         return value.asIntegerValue().asByte();
       case SHORT:

--- a/core/src/main/java/overflowdb/storage/OdbStorage.java
+++ b/core/src/main/java/overflowdb/storage/OdbStorage.java
@@ -31,6 +31,7 @@ public class OdbStorage implements AutoCloseable {
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   private final File mvstoreFile;
+  private final StringInterner stringInterner;
   private FileStore mvstoreFileStore;
   protected MVStore mvstore;
   private MVMap<Long, byte[]> nodesMVMap;
@@ -41,19 +42,20 @@ public class OdbStorage implements AutoCloseable {
   private ArrayList<String> stringToIntReverseMappings;
   private int libraryVersionsIdCurrentRun;
 
-  public static OdbStorage createWithTempFile() {
-    return new OdbStorage(Optional.empty());
+  public static OdbStorage createWithTempFile(StringInterner stringInterner) {
+    return new OdbStorage(Optional.empty(), stringInterner);
   }
 
   /**
    * create with specific mvstore file - which may or may not yet exist.
    * mvstoreFile won't be deleted at the end (unlike temp file constructors above)
    */
-  public static OdbStorage createWithSpecificLocation(final File mvstoreFile) {
-    return new OdbStorage(Optional.ofNullable(mvstoreFile));
+  public static OdbStorage createWithSpecificLocation(final File mvstoreFile, StringInterner stringInterner) {
+    return new OdbStorage(Optional.ofNullable(mvstoreFile), stringInterner);
   }
 
-  private OdbStorage(final Optional<File> mvstoreFileMaybe) {
+  private OdbStorage(final Optional<File> mvstoreFileMaybe, StringInterner stringInterner) {
+    this.stringInterner = stringInterner;
     if (mvstoreFileMaybe.isPresent()) {
       mvstoreFile = mvstoreFileMaybe.get();
       if (mvstoreFile.exists() && mvstoreFile.length() > 0) {
@@ -204,7 +206,7 @@ public class OdbStorage implements AutoCloseable {
   public String reverseLookupStringToIntMapping(int stringId) {
     getStringToIntMappings(); //ensure everything is initialized
     String string = stringToIntReverseMappings.get(stringId);
-    return StringInterner.intern(string);
+    return stringInterner.intern(string);
   }
 
   private void ensureMVStoreAvailable() {

--- a/core/src/main/java/overflowdb/util/StringInterner.java
+++ b/core/src/main/java/overflowdb/util/StringInterner.java
@@ -3,11 +3,14 @@ package overflowdb.util;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class StringInterner {
-  private static ConcurrentHashMap<String, String> internedStrings = new ConcurrentHashMap<>();
+  private ConcurrentHashMap<String, String> internedStrings = new ConcurrentHashMap<>();
 
-  public static String intern(String s){
+  public String intern(String s){
     String interned = internedStrings.putIfAbsent(s, s);
     return interned == null ? s : interned;
   }
 
+  public void clear() {
+    internedStrings.clear();
+  }
 }


### PR DESCRIPTION
Not sure why we initially made it static, but it was never a good
idea, and it is a very obvious memory leak.