### PR TITLE
prevent duplication of nodeRef on deserialization

### DIFF
--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -173,7 +173,7 @@ public final class Graph implements AutoCloseable {
       throw new IllegalArgumentException("No NodeFactory for label=" + label + " available.");
     }
     final NodeFactory factory = nodeFactoryByLabel.get(label);
-    final NodeDb node = factory.createNode(this, idValue);
+    final NodeDb node = factory.createNode(this, idValue, null);
     PropertyHelper.attachProperties(node, keyValues);
     registerNodeRef(node.ref);
 

--- a/core/src/main/java/overflowdb/NodeFactory.java
+++ b/core/src/main/java/overflowdb/NodeFactory.java
@@ -7,8 +7,12 @@ public abstract class NodeFactory<V extends NodeDb> {
 
   public abstract NodeRef<V> createNodeRef(Graph graph, long id);
 
-  public V createNode(Graph graph, long id) {
-    final NodeRef<V> ref = createNodeRef(graph, id);
+  public  V createNode(Graph graph, long id) {
+  return createNode(graph, id, null);
+  }
+
+  public V createNode(Graph graph, long id, NodeRef<V> ref) {
+    if(ref == null) ref = createNodeRef(graph, id);
     final V node = createNode(ref);
     node.markAsDirty(); //freshly created, i.e. not yet serialized
     ref.setNode(node);

--- a/core/src/main/java/overflowdb/NodeFactory.java
+++ b/core/src/main/java/overflowdb/NodeFactory.java
@@ -8,7 +8,7 @@ public abstract class NodeFactory<V extends NodeDb> {
   public abstract NodeRef<V> createNodeRef(Graph graph, long id);
 
   public  V createNode(Graph graph, long id) {
-  return createNode(graph, id, null);
+    return createNode(graph, id, null);
   }
 
   public V createNode(Graph graph, long id, NodeRef<V> ref) {

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -101,7 +101,7 @@ public abstract class NodeRef<N extends NodeDb> extends Node {
     } else {
       final N node = readFromDisk();
       if (node == null) throw new IllegalStateException("unable to read node from disk; id=" + id);
-      assert(this.node == node);
+      if (this.node != node) throw new AssertionError("invalid state after reading node from dist; id=" + id);
       graph.registerNodeRef(this);
       return node;
     }

--- a/core/src/main/java/overflowdb/NodeRef.java
+++ b/core/src/main/java/overflowdb/NodeRef.java
@@ -99,9 +99,9 @@ public abstract class NodeRef<N extends NodeDb> extends Node {
     if (ref != null) {
       return ref;
     } else {
-      final N node = readFromDisk(id);
+      final N node = readFromDisk();
       if (node == null) throw new IllegalStateException("unable to read node from disk; id=" + id);
-      this.node = node;
+      assert(this.node == node);
       graph.registerNodeRef(this);
       return node;
     }
@@ -115,9 +115,9 @@ public abstract class NodeRef<N extends NodeDb> extends Node {
     this.node = node;
   }
 
-  private final N readFromDisk(long nodeId) throws IOException {
-    byte[] bytes = graph.storage.getSerializedNode(nodeId);
-    return (N) graph.nodeDeserializer.deserialize(bytes);
+  private final N readFromDisk() throws IOException {
+    byte[] bytes = graph.storage.getSerializedNode(this.id);
+    return (N) graph.nodeDeserializer.deserialize(bytes, this);
   }
 
   public long id() {

--- a/core/src/main/java/overflowdb/storage/NodeDeserializer.java
+++ b/core/src/main/java/overflowdb/storage/NodeDeserializer.java
@@ -33,7 +33,10 @@ public class NodeDeserializer extends BookKeeper {
     this.storage = storage;
   }
 
-  public final NodeDb deserialize(byte[] bytes) throws IOException {
+  public final NodeDb deserialize(byte[] bytes) throws  IOException {
+    return deserialize(bytes, null);
+  }
+  public final NodeDb deserialize(byte[] bytes, NodeRef<?> ref) throws IOException {
     long startTimeNanos = getStartTimeNanos();
     if (null == bytes)
       return null;
@@ -44,7 +47,7 @@ public class NodeDeserializer extends BookKeeper {
     final Object[] properties = unpackProperties(unpacker);
 
     final String label = storage.reverseLookupStringToIntMapping(labelStringId);
-    NodeDb node = getNodeFactory(label).createNode(graph, id);
+    NodeDb node = getNodeFactory(label).createNode(graph, id, ref);
     PropertyHelper.attachProperties(node, properties);
 
     deserializeEdges(unpacker, node, Direction.OUT);


### PR DESCRIPTION
As we saw from https://github.com/ShiftLeftSecurity/overflowdbv2/pull/11 , we have a problem when deserializing nodes: There are too many and too heavy (https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/205) NodeRefs.

This addresses the "too many" part. The issue is the following: When we deserialize a node, then we ask NodeFactory to please give us a new NodeDb object with the data. But the API helpfully also allocates a NodeRef object that is kept alive by the NodeDb!

So the pointer structure when deserializing looks like this:
```
NodeRef1 -(`private Node node`)-> NodeDb1 -(`private NodeRef ref`)-> NodeRef2 -(`private Node node`)-> NodeDb1
```
This is of course nonsense. We fix this by passing pre-existing NodeRef pointers into the `createNode` function and only allocate a new `NodeRef` when that is `null`.

This should save one NodeRef per node, which weighs 32 bytes (with https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/205; before it was 40 bytes) .

PS. can you add some more eyes that I got the referenceManager queue / registerRef right? We never want to add a nodeRef twice, nor do we want to forget it.