### PR TITLE
copy edge order

### DIFF
--- a/core-tests/src/test/java/overflowdb/GraphTest.java
+++ b/core-tests/src/test/java/overflowdb/GraphTest.java
@@ -11,6 +11,7 @@ import overflowdb.testdomains.simple.TestEdge;
 import overflowdb.testdomains.simple.TestNode;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -89,5 +90,37 @@ public class GraphTest {
     assertEquals(graph.nodeCount(), 2);
     assertEquals(graph.edgeCount(), 1);
   }
+
+  @Test
+  public void shouldCorrectlyCloneEdgeOrders() {
+    Config config = Config.withoutOverflow();
+    Graph graph = SimpleDomain.newGraph(config);
+    Node n0 = graph.addNode(TestNode.LABEL, TestNode.STRING_PROPERTY, "n0");
+    Node n1 = graph.addNode(TestNode.LABEL, TestNode.STRING_PROPERTY, "n1");
+    Node n2 = graph.addNode(TestNode.LABEL, TestNode.STRING_PROPERTY, "n2");
+    n1.addEdge(TestEdge.LABEL, n2);
+    n0.addEdge(TestEdge.LABEL, n2);
+
+    // copy graph
+    Graph graph2 = SimpleDomain.newGraph(config);
+    graph.copyTo(graph2);
+
+    //verify order of in-edges on n1
+    Iterator<Node> orig = n2.in();
+    assertEquals(orig.next().property(TestNode.STRING_PROPERTY), "n1");
+    assertEquals(orig.next().property(TestNode.STRING_PROPERTY), "n0");
+    assertEquals(orig.hasNext(), false);
+
+    //same for the copy
+
+    Node n0Copy = graph2.node(n0.id());
+    Node n1Copy = graph2.node(n1.id());
+    Node n2Copy = graph2.node(n2.id());
+    Iterator<Node> copy = n2Copy.in();
+    assertEquals(copy.next().property(TestNode.STRING_PROPERTY), "n1");
+    assertEquals(copy.next().property(TestNode.STRING_PROPERTY), "n0");
+    assertEquals(copy.hasNext(), false);
+  }
+
 
 }

--- a/core/src/main/java/overflowdb/Graph.java
+++ b/core/src/main/java/overflowdb/Graph.java
@@ -398,11 +398,18 @@ public final class Graph implements AutoCloseable {
     nodes().forEachRemaining(node -> {
       destination.addNode(node.id(), node.label(), PropertyHelper.toKeyValueArray(node.propertiesMap()));
     });
+    nodes().forEachRemaining( node -> {
+      NodeDb mapped =  ((NodeRef<NodeDb>) destination.node(node.id())).get();
 
-    edges().forEachRemaining(edge -> {
-      final Node inNode = destination.node(edge.inNode().id());
-      final Node outNode = destination.node(edge.outNode().id());
-      outNode.addEdge(edge.label(), inNode, PropertyHelper.toKeyValueArray(edge.propertiesMap()));
+      node.outE().forEachRemaining(edge -> {
+                NodeRef<?> other = (NodeRef<?>) destination.node(edge.inNode().id());
+                mapped.storeAdjacentNode(Direction.OUT, edge.label(), other, PropertyHelper.toKeyValueArray(edge.propertiesMap()));
+      });
+      node.inE().forEachRemaining(edge -> {
+        NodeRef<?> other = (NodeRef<?>) destination.node(edge.outNode().id());
+        mapped.storeAdjacentNode(Direction.IN, edge.label(), other, PropertyHelper.toKeyValueArray(edge.propertiesMap()));
+      });
+
     });
   }
 


### PR DESCRIPTION
This fixes https://github.com/ShiftLeftSecurity/overflowdb/issues/357

Turns out that the API for adding half-edges already exists, we just need to use it.

The first commit adds a unit test for the ordering of neighbors that fails and is fixed in the second commit.