### PR TITLE
add unit test to document (counter-intutive?) collectAll path-tracking behavior

### DIFF
--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -57,6 +57,11 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"))
       }
 
+      "collectAll: Do we really want to include intermediate reulsts?" in {
+        centerTrav.enablePathTracking.collectAll[Thing].path.toList shouldBe List(
+          Seq(center, center))
+      }
+
       "filter" in {
         centerTrav.enablePathTracking.followedBy.nameStartsWith("R").followedBy.path.toSetMutable shouldBe Set(
           Seq(center, r1, r2))


### PR DESCRIPTION
This documents the imo counter-intuitive path-tracking behavior of collectAll: The step is part of the path.

collectAll is used in our steps like `isMethod`. I think these should behave like filters, i.e. don't add to the path.

What do you think?

If we decide to change this, I would do that in a follow-up and first merge the unit-test that documents current behavior.