### PR TITLE
collectAll path tracking

### DIFF
--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -57,9 +57,9 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"))
       }
 
-      "collectAll: includes intermediate results (this behavior is undesired)" in {
+      "collectAll: does not include intermediate results" in {
         centerTrav.enablePathTracking.collectAll[Thing].path.toList shouldBe List(
-          Seq(center, center))
+          Seq(center))
       }
 
       "filter" in {

--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -57,6 +57,11 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"))
       }
 
+      "collectAll: Do we really want to include intermediate reulsts?" in {
+        centerTrav.enablePathTracking.collectAll[Thing].path.toList shouldBe List(
+          Seq(center, center))
+      }
+
       "filter" in {
         centerTrav.enablePathTracking.followedBy.nameStartsWith("R").followedBy.path.toSetMutable shouldBe Set(
           Seq(center, r1, r2))

--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -57,7 +57,7 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"))
       }
 
-      "collectAll: includes intermediate reulsts (this behavior is undesired)" in {
+      "collectAll: includes intermediate results (this behavior is undesired)" in {
         centerTrav.enablePathTracking.collectAll[Thing].path.toList shouldBe List(
           Seq(center, center))
       }

--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -57,7 +57,7 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"))
       }
 
-      "collectAll: Do we really want to include intermediate reulsts?" in {
+      "collectAll: includes intermediate reulsts (this behavior is undesired)" in {
         centerTrav.enablePathTracking.collectAll[Thing].path.toList shouldBe List(
           Seq(center, center))
       }

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -61,10 +61,10 @@ class Traversal[+A](elements: IterableOnce[A])
   def cast[B]: Traversal[B] =
     this.asInstanceOf[Traversal[B]]
 
-  /** collects and all elements of the given type */
-  @Doc(info = "collects and all elements of the provided type")
-  def collectAll[B: ClassTag]: Traversal[B] =
-    collect { case b: B => b}
+  /** collects all elements of the given class (beware of type-erasure) */
+  @Doc(info = "collects all elements of the provided class (beware of type-erasure)")
+  def collectAll[B](implicit ev: ClassTag[B]): Traversal[B] =
+    filter(ev.runtimeClass.isInstance).asInstanceOf[Traversal[B]]
 
   /** filters out everything that is _not_ the given value */
   @Doc(info = "filters out everything that is _not_ the given value")


### PR DESCRIPTION
To be merged after https://github.com/ShiftLeftSecurity/overflowdb/pull/360 (I want an unsquashed commit in our history that documents/tests current undesired behavior).

The code may superficially look more complicated than the old code. This is not the case; in fact the code is now much simpler: I unsugared the implicit classtag and its `unapply` method from the match statement.

The old documentation was somewhat optimistic, referring to "collect ... of type". I clarified that -- collectAll refers to the erased java (runtime) class, not the scala (compile-time) type.