### PR TITLE
document counter-intuitive union choose coalesce path tracking

### DIFF
--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -159,12 +159,13 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
             case "L1" => _.out // -> L2
             case "R1" => _.repeat(_.out)(_.maxDepth(3)) // -> R4
           }.property(Name).path.toSetMutable shouldBe Set(
-          Seq(r1, r4, "R4"),
+          Seq(r1, r4, "R4"), //fixme: Is this really what we want? Shouldn't the repeat be path-tracked?
           Seq(l1, l2, "L2")
         )
       }
 
       "coalesce" in {
+        //fixme: Is this really what we want? Shouldn't substeps be path-tracked?
         var traversalInvoked = false
         centerTrav.enablePathTracking.coalesce(
           _.out("doesn't exist"),
@@ -175,6 +176,15 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"),
         )
         traversalInvoked shouldBe false
+      }
+
+      "union" in {
+        //fixme: Is this really what we want? Shouldn't substeps be path-tracked?
+         centerTrav.enablePathTracking.union(_.out.out).path.toSetMutable shouldBe Set(
+          Seq(center, l2),
+          Seq(center, r2)
+         )
+
       }
 
     }

--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -57,9 +57,9 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"))
       }
 
-      "collectAll: includes intermediate results (this behavior is undesired)" in {
+      "collectAll: does not include intermediate results" in {
         centerTrav.enablePathTracking.collectAll[Thing].path.toList shouldBe List(
-          Seq(center, center))
+          Seq(center))
       }
 
       "filter" in {

--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -57,6 +57,11 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"))
       }
 
+      "collectAll: Do we really want to include intermediate reulsts?" in {
+        centerTrav.enablePathTracking.collectAll[Thing].path.toList shouldBe List(
+          Seq(center, center))
+      }
+
       "filter" in {
         centerTrav.enablePathTracking.followedBy.nameStartsWith("R").followedBy.path.toSetMutable shouldBe Set(
           Seq(center, r1, r2))

--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -57,7 +57,7 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"))
       }
 
-      "collectAll: includes intermediate reulsts (this behavior is undesired)" in {
+      "collectAll: includes intermediate results (this behavior is undesired)" in {
         centerTrav.enablePathTracking.collectAll[Thing].path.toList shouldBe List(
           Seq(center, center))
       }

--- a/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/traversal/PathTraversalTests.scala
@@ -57,7 +57,7 @@ class PathTraversalTests extends AnyWordSpec with ExampleGraphSetup {
           Seq(center, r1, "R1"))
       }
 
-      "collectAll: Do we really want to include intermediate reulsts?" in {
+      "collectAll: includes intermediate reulsts (this behavior is undesired)" in {
         centerTrav.enablePathTracking.collectAll[Thing].path.toList shouldBe List(
           Seq(center, center))
       }

--- a/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/Traversal.scala
@@ -61,10 +61,10 @@ class Traversal[+A](elements: IterableOnce[A])
   def cast[B]: Traversal[B] =
     this.asInstanceOf[Traversal[B]]
 
-  /** collects and all elements of the given type */
-  @Doc(info = "collects and all elements of the provided type")
-  def collectAll[B: ClassTag]: Traversal[B] =
-    collect { case b: B => b}
+  /** collects all elements of the given class (beware of type-erasure) */
+  @Doc(info = "collects all elements of the provided class (beware of type-erasure)")
+  def collectAll[B](implicit ev: ClassTag[B]): Traversal[B] =
+    filter(ev.runtimeClass.isInstance).asInstanceOf[Traversal[B]]
 
   /** filters out everything that is _not_ the given value */
   @Doc(info = "filters out everything that is _not_ the given value")


### PR DESCRIPTION
Could be squashed into https://github.com/ShiftLeftSecurity/overflowdb/pull/361 (why is github so slow today?)

This is more of a start for a discussion with code attached: The union, choose and coalesce steps take in a bunch of `transform: Traversal[A] => Traversal[B]` functions that may be composed of multiple traversal sub-steps. Should the sub-steps partake in path-tracking?

Since there is a bunch of commits stacked into this PR, the relevant question is
```scala
      "union" in {
        //fixme: Is this really what we want? Shouldn't substeps be path-tracked?
         centerTrav.enablePathTracking.union(_.out.out).path.toSetMutable shouldBe Set(
          Seq(center, l2),
          Seq(center, r2)
         )
      }
```
Here, one could argue that the result should rather be
```scala
Set(
          Seq(center, l1, l2),
          Seq(center, r1, r2)
         )
```
i.e. that all the traversal-style substeps inside the `union` should be path-tracked.

If this was a green-field decision then I would emphatically say yes! They absolutely should partake in path tracking!

Could we implement that? Yes we could. Would be slightly annoying for odbv2, but definitely possible.

Do we need to "fix" / change / improve that? 

My personal opinion is that this entire DSL-gremlin "`Traversal` instead of nice clean loops / functions" stuff is a legacy boondoggle. We need to fix hard bugs and attempt to mostly maintain compat. Otherwise we should place path-tracking, repeat, union, coalesce, choose, where, and, or, etc all into maintenance mode, attempt to avoid that in our code, and even consider adding the `@deprecate` label to warn users away.  

That is a strategy decision that is not for me alone to make, though -- cc @fabsx00 @DavidBakerEffendi @itsacoderepo @ml86 @mpollmeier whether you think all these Traversal features are legacy / maintenance-eventually-deprecate or important / continue-to-improve.