### PR TITLE
github actions: upgrade to ubuntu 22.04

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR
 on: pull_request
 jobs:
   pr:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     concurrency: release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/traversal-tests/src/test/scala/overflowdb/algorithm/DependencySequencerTests.scala
+++ b/traversal-tests/src/test/scala/overflowdb/algorithm/DependencySequencerTests.scala
@@ -48,7 +48,7 @@ class DependencySequencerTests extends AnyWordSpec {
   }
 
   "larger graph 1" in {
-
+    // format: off
     /** \+-------------------+
       * \| v
       * \+---+ +---+ +---+ +---+
@@ -59,6 +59,7 @@ class DependencySequencerTests extends AnyWordSpec {
       * \| D | ----------------+
       * \+---+
       */
+    // format: on
     val A = new Node("A")
     val B = new Node("B", Set(A))
     val C = new Node("C", Set(B))
@@ -68,7 +69,7 @@ class DependencySequencerTests extends AnyWordSpec {
   }
 
   "larger graph 2" in {
-
+    // format: off
     /** \+-----------------------------+
       * \| v
       * \+---+ +---+ +---+ +---+ +---+
@@ -79,6 +80,7 @@ class DependencySequencerTests extends AnyWordSpec {
       * \| C | --------------------------+
       * \+---+
       */
+    // format: on
     val A = new Node("A")
     val B = new Node("B", Set(A))
     val C = new Node("C", Set(B))


### PR DESCRIPTION
ubuntu 18.04 got deprecated
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/