### PR TITLE
table rendering: use minimum width

### DIFF
--- a/traversal/src/main/scala/overflowdb/traversal/help/Table.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/help/Table.scala
@@ -23,7 +23,11 @@ case class Table(columnNames: Seq[String], rows: Seq[Seq[String]]) {
       table.addRule()
       table.getContext.setGridTheme(TA_GridThemes.FULL)
       table.setTextAlignment(TextAlignment.LEFT)
-      table.render(availableWidthProvider.apply())
+
+      // some terminal emulators (e.g. on github actions CI) report to have a width of 0...
+      // that doesn't work for rendering a table, so we compensate by using a minimum width
+      val renderingWidth = math.max(availableWidthProvider.apply(), 60)
+      table.render(renderingWidth)
     }
   }
 


### PR DESCRIPTION
some terminal emulators (e.g. on github actions CI) report to have a width of 0...
that doesn't work for rendering a table, so we compensate by using a minimum width

from the joern testDistro.sh output on github actions:
```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at io.joern.joerncli.console.ReplBridge$.predefLines(ReplBridge.scala:17)
	at io.joern.console.BridgeBase.createPredefFile(BridgeBase.scala:211)
	at io.joern.console.BridgeBase.createPredefFile$(BridgeBase.scala:45)
	at io.joern.joerncli.console.ReplBridge$.createPredefFile(ReplBridge.scala:6)
	at io.joern.console.ScriptExecution.runScript(BridgeBase.scala:261)
	at io.joern.console.ScriptExecution.runScript$(BridgeBase.scala:254)
	at io.joern.joerncli.console.ReplBridge$.runScript(ReplBridge.scala:6)
	at io.joern.console.BridgeBase.run(BridgeBase.scala:194)
	at io.joern.console.BridgeBase.run$(BridgeBase.scala:45)
	at io.joern.joerncli.console.ReplBridge$.run(ReplBridge.scala:6)
	at io.joern.joerncli.console.ReplBridge$.main(ReplBridge.scala:11)
	at io.joern.joerncli.console.ReplBridge.main(ReplBridge.scala)
Caused by: java.lang.IllegalArgumentException: wrong width argument: width must allow for borders
	at de.vandermeer.asciitable.CWC_AbsoluteEven.calculateColumnWidths(CWC_AbsoluteEven.java:45)
	at de.vandermeer.asciitable.AT_Renderer.renderAsCollection(AT_Renderer.java:167)
	at de.vandermeer.asciitable.AT_Renderer.render(AT_Renderer.java:128)
	at de.vandermeer.asciitable.AsciiTable.render(AsciiTable.java:191)
	at overflowdb.traversal.help.Table.render(Table.scala:26)
	at io.joern.console.Help$.overview(Help.scala:36)
	at io.joern.console.Help$.codeForHelpCommand(Help.scala:70)
	at io.joern.joerncli.console.Predefined$.<clinit>(Predefined.scala:30)
	... 12 more
```