### PR TITLE
fix ConcurrentModificationException

### DIFF
--- a/core/src/main/java/overflowdb/ReferenceManager.java
+++ b/core/src/main/java/overflowdb/ReferenceManager.java
@@ -152,8 +152,10 @@ public class ReferenceManager implements AutoCloseable, HeapUsageMonitor.HeapNot
    * useful when saving the graph
    */
   public void clearAllReferences() {
-    nodesWriter.writeAndClearBatched(clearableRefs.spliterator(), clearableRefs.size());
-    logger.debug("cleared all clearable references");
+    synchronized (clearableRefs){
+      nodesWriter.writeAndClearBatched(clearableRefs.spliterator(), clearableRefs.size());
+      logger.debug("cleared all clearable references");
+    }
   }
 
   @Override


### PR DESCRIPTION
I noticed that the use of `clearableRefs` in the method `clearAllReferences` method is incorrect. 
The type of `clearableRefs` is synchronizedList. Although the safeList is thread-safe, its iterator is not.
According to [Javadocs](https://docs.oracle.com/javase%2F9%2Fdocs%2Fapi%2F%2F/java/util/Collections.html) :
> It is imperative that the user manually synchronize on the returned collection when traversing it via Iterator, **Spliterator** or Stream

I think this is the root cause of the occurrence of ConcurrentModificationException.


To analyze more specifically, why is there a very **small chance** of a ConcurrentModificationException occurring

When the use of heap memory exceeds the limit, `notificationListener.notifyHeapAboveThreshold()` will be called. It runs the clearing of references **asynchronously** there, which involves modifying **clearableRefs**.

Is it possible that when the `clearAllReferences()` method is called, some of the threads initiated by the `notificationListener.notifyHeapAboveThreshold()` method have not finished executing. This leads to the use of `clearableRefs.spliterator()` to generate the iterator of `clearableRefs` for traversal, and `clearableRefs` is modified by other threads again.
![image](https://github.com/ShiftLeftSecurity/overflowdb/assets/31243506/d41b8834-6812-48ae-b25d-121247c0ff30)

Resolves #424 