### PR TITLE
downgrade to scala 3.3 LTS

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,20 +2,16 @@ name: PR
 on: pull_request
 jobs:
   pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: 19
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.coursier
-          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt scalafmtCheck Test/scalafmtCheck +test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
 jobs:
   release:
     concurrency: release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: apt-get update
@@ -20,16 +20,12 @@ jobs:
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: 19
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.coursier
-          key: ${{ runner.os }}-sbt-${{ hashfiles('**/build.sbt') }}
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt +test ciReleaseTagNextVersion ciReleaseSonatype
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,7 @@
 name := "overflowdb"
 ThisBuild / organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.13"
-ThisBuild / crossScalaVersions := Seq("2.13.13", "3.4.1")
-// TODO once we're on Scala 3.2.2: make chained implicits in `Implicits.scala` available again
-// also, change other places that have temporarily been adapted - search for `TODO Scala 3.2.2`
+ThisBuild / crossScalaVersions := Seq("2.13.13", "3.3.6")
 publish / skip := true
 
 lazy val core = project.in(file("core"))


### PR DESCRIPTION
Projects that are used as libraries should stick to the latest LTS version.

Scala 3 guarantees backward compatibility across minor releases in the entire 3.x series, but not forward compatibility. This means that libraries compiled with any Scala 3.x version can be used in projects compiled with any Scala 3.y version with y >= x.

https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html#library-maintainers
https://docs.scala-lang.org/overviews/core/binary-compatibility-of-scala-releases.html